### PR TITLE
p7zip-full dependency

### DIFF
--- a/s2e_env/dat/config.yaml
+++ b/s2e_env/dat/config.yaml
@@ -39,6 +39,7 @@ dependencies:
         - xz-utils
         - docker.io
         - p7zip
+        - p7zip-full
 
         # S2E dependencies
         - libdwarf-dev

--- a/s2e_env/dat/config.yaml
+++ b/s2e_env/dat/config.yaml
@@ -38,7 +38,6 @@ dependencies:
         - python-pip
         - xz-utils
         - docker.io
-        - p7zip
         - p7zip-full
 
         # S2E dependencies


### PR DESCRIPTION
Added 'p7zip-full' as a dependency to install /usr/bin/7z as 'p7zip' only installs /usr/bin/7zr and /usr/bin/p7zip. (Ubuntu 16.04 LTS Server x86-64)

