### PR TITLE
basic_block_coverage: improvements

### DIFF
--- a/s2e_env/commands/code_coverage/__init__.py
+++ b/s2e_env/commands/code_coverage/__init__.py
@@ -64,6 +64,11 @@ def parse_tb_file(path, module):
             logger.warning('Failed to parse translation block JSON file %s',
                            path)
             return None
+
+    if not tb_coverage_data:
+        logger.warning('Translation block JSON file %s is empty', path)
+        return None
+
     if module not in tb_coverage_data:
         logger.warning('Target %s not found in translation block JSON file %s',
                        module, path)

--- a/s2e_env/commands/code_coverage/basic_block.py
+++ b/s2e_env/commands/code_coverage/basic_block.py
@@ -114,12 +114,13 @@ class BasicBlockCoverage(ProjectCommand):
         # Calculate the basic block coverage information
         bb_coverage = _basic_block_coverage(bbs, tbs)
 
-        # Write the basic block information to a JSON file
-        bb_coverage_file = self._save_basic_block_coverage(bb_coverage)
-
         # Calculate some statistics
         total_bbs = len(bbs)
         covered_bbs = len(bb_coverage)
+
+        # Write the basic block information to a JSON file
+        bb_coverage_file = self._save_basic_block_coverage(bb_coverage,
+                                                           total_bbs)
 
         return self.RESULTS.format(bb_file=bb_coverage_file,
                                    num_bbs=total_bbs,
@@ -242,11 +243,16 @@ class BasicBlockCoverage(ProjectCommand):
 
         return list(covered_tbs)
 
-    def _save_basic_block_coverage(self, basic_blocks):
+    def _save_basic_block_coverage(self, basic_blocks, total_bbs):
         """
         Write the basic block coverage information to a JSON file.
 
-        Returns the path of the JSON file.
+        Args:
+            basic_blocks: Covered basic blocks.
+            total_bbs: The total number of basic blocks in the program.
+
+        Returns:
+            The path of the JSON file.
         """
         bb_coverage_file = self.project_path('s2e-last',
                                              'basic_block_coverage.json')
@@ -256,7 +262,13 @@ class BasicBlockCoverage(ProjectCommand):
         to_dict = lambda bb: {'start_addr': bb.start_addr,
                               'end_addr': bb.end_addr,
                               'function': bb.function}
-        bbs_json = [to_dict(bb) for bb in basic_blocks]
+        bbs_json = {
+            'stats': {
+                'total_basic_blocks': total_bbs,
+                'covered_basic_blocks': len(basic_blocks),
+            },
+            'coverage': [to_dict(bb) for bb in basic_blocks],
+        }
 
         with open(bb_coverage_file, 'w') as f:
             json.dump(bbs_json, f)

--- a/s2e_env/commands/code_coverage/basic_block.py
+++ b/s2e_env/commands/code_coverage/basic_block.py
@@ -103,6 +103,8 @@ class BasicBlockCoverage(ProjectCommand):
 
         # Get the basic block information
         bbs = self._get_basic_blocks(ida_path, target_path)
+        if not bbs:
+            raise CommandError('No basic block information found by IDA Pro')
 
         # Get translation block coverage information
         tbs = self._get_tb_coverage(os.path.basename(target_path))


### PR DESCRIPTION
Occasionally IDA will fail to generate any basic blocks (e.g. due to heavy obfuscation), leading to a divide-by-zero in the statistics calculation. I've added some checks to avoid this.