### PR TITLE
bootstrap.sh: hide unused functions

### DIFF
--- a/s2e_env/templates/bootstrap.cgc.sh
+++ b/s2e_env/templates/bootstrap.cgc.sh
@@ -3,6 +3,10 @@ function execute_target {
     ./${TARGET} > /tmp/out 2>&1
 }
 
+{% if use_seeds %}
+# Executes the target with a seed file as input.
+# You can customize this function if you need to do special processing
+# on the seeds, tweak arguments, etc.
 function execute_target_with_seed {
     TARGET="$1"
     SEED_FILE="$2"
@@ -16,6 +20,7 @@ function execute_target_with_seed {
     chmod +x ${SEED_FILE}
     cb-test --directory $(pwd) --xml ${SEED_FILE} --cb ${TARGET} --should_core --timeout 3600 2>&1
 }
+{% endif %}
 
 function target_init {
     # Patch cb-test so that it works without core dumps

--- a/s2e_env/templates/bootstrap.linux.sh
+++ b/s2e_env/templates/bootstrap.linux.sh
@@ -19,6 +19,7 @@ function execute_target {
     {% endif %}
 }
 
+{% if use_seeds %}
 # Executes the target with a seed file as input.
 # You can customize this function if you need to do special processing
 # on the seeds, tweak arguments, etc.
@@ -36,6 +37,7 @@ function execute_target_with_seed {
 
     ./${TARGET} {{ target_args | join(' ') }} > /dev/null 2> /dev/null
 }
+{% endif %}
 
 # Nothing more to initialize on Linux
 function target_init {

--- a/s2e_env/templates/bootstrap.windows.sh
+++ b/s2e_env/templates/bootstrap.windows.sh
@@ -12,6 +12,7 @@ function execute_target {
     ./${TARGET} {{ target_args | join(' ') }} > /dev/null 2> /dev/null
 }
 
+{% if use_seeds %}
 # Executes the target with a seed file as input.
 # You can customize this function if you need to do special processing
 # on the seeds, tweak arguments, etc.
@@ -29,6 +30,7 @@ function execute_target_with_seed {
 
     ./${TARGET} {{ target_args | join(' ') }} > /dev/null 2> /dev/null
 }
+{% endif %}
 
 function target_init {
     local PREFIX


### PR DESCRIPTION
Do not render the `execute_target_with_seed` function if seeds are not in use - makes the bootstrap.sh file simpler and easier to understand