### PR TITLE
Added import and export commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,11 @@ A typical workflow is therefore:
 7. After your analysis has finished, a number of subcommands exist to analyze
    and summarize your results, e.g. the ``coverage`` subcommand, etc.
 
-The `s2e info` command can be used to display a summary of the S2E environment.
-To grab the latest changes from the git repositories, run `s2e update`.
+Other useful commands:
+
+* `s2e info` can be used to display a summary of the S2E environment.
+* To download the latest changes from the git repositories, run `s2e update`.
+* Projects can be shared using `s2e export_project` and `s2e import_project`.
 
 ## Environment structure
 

--- a/s2e_env/commands/export_project.py
+++ b/s2e_env/commands/export_project.py
@@ -1,0 +1,159 @@
+"""
+Copyright (c) 2017 Dependable Systems Laboratory, EPFL
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+
+import glob
+import json
+import logging
+import os
+import shutil
+import sys
+
+from sh import tar, ErrorReturnCode
+
+try:
+    from tempfile import TemporaryDirectory
+except ImportError:
+    from s2e_env.utils.tempdir import TemporaryDirectory
+
+from s2e_env.command import ProjectCommand, CommandError
+from s2e_env.commands.import_export import S2E_ENV_PLACEHOLDER, copy_and_rewrite_files
+
+
+logger = logging.getLogger('export')
+
+
+class Command(ProjectCommand):
+    """
+    Export a project so that it can be shared with other S2E environments.
+
+    All files listed under ``exported_files`` in ``config.yaml`` will be
+    exported. Each of these files will be checked for references to the S2E
+    environment path, and all occurances of this path will be replaced by a
+    placeholder marker. When importing the project into a new S2E environment,
+    this placeholder will be rewritten with the path of the new S2E
+    environment.
+
+    The user can also export previous analysis results (i.e. all of the
+    ``s2e-out-*`` directories) if required.
+    """
+
+    help = 'Export an S2E project as an archive'
+
+    def add_arguments(self, parser):
+        super(Command, self).add_arguments(parser)
+
+        parser.add_argument('output_path', nargs='?',
+                            help='The path to the exported project archive. '
+                                 'Defaults to <project_name>.tar.xz in the '
+                                 'current working directory')
+        parser.add_argument('-r', '--export-results', action='store_true',
+                            help='Export the results in the s2e-out-* directories')
+
+    def handle(self, *args, **options):
+        # Name the project archive if it doesn't already have a name
+        output_path = options['output_path']
+        if not output_path:
+            output_path = self.env_path('%s.tar.xz' % self._project_name)
+
+        with TemporaryDirectory() as temp_dir:
+            # Store all of the exported files in a temporary directory so that
+            # we can just execute tar on the entire directory
+            export_dir = os.path.join(temp_dir, self._project_name)
+            os.mkdir(export_dir)
+
+            # Copy project scripts and config files and rewrite the S2E
+            # environment path in these files
+            logger.info('Rewriting project files')
+            copy_and_rewrite_files(self.project_path(), export_dir,
+                                   self.env_path(), S2E_ENV_PLACEHOLDER)
+
+            with open(os.path.join(export_dir, 'project.json'), 'r+') as f:
+                proj_desc = json.load(f)
+
+                # Rewrite the target_path entry in the given project.json. This
+                # is done because when we import the project the target will no
+                # longer be a symlink
+                proj_desc['target_path'] = \
+                    os.path.join(proj_desc['project_dir'], proj_desc['target'])
+
+                # Export the recipes directory
+                if proj_desc['use_recipes']:
+                    recipes_dir = os.path.basename(proj_desc['recipes_dir'])
+                    shutil.copytree(proj_desc['recipes_dir'],
+                                    os.path.join(export_dir, recipes_dir))
+
+                # Export the seeds directory
+                if proj_desc['use_seeds']:
+                    seeds_dir = os.path.basename(proj_desc['seeds_dir'])
+                    shutil.copytree(proj_desc['seeds_dir'],
+                                    os.path.join(export_dir, seeds_dir))
+
+                # Update the project.json in the temporary directory
+                proj_desc_json = json.dumps(proj_desc, sort_keys=True, indent=4)
+                f.seek(0)
+                f.write(proj_desc_json)
+                f.truncate()
+
+            # Copy the target into the temporary directory
+            logger.info('Copying target from %s', self._project_desc['target_path'])
+            shutil.copyfile(self._project_desc['target_path'],
+                            os.path.join(export_dir, self._project_desc['target']))
+
+            # Copy previous results
+            if options['export_results']:
+                self._copy_previous_results(export_dir)
+
+            # Create the archive of the temporary directory's contents
+            self._create_archive(output_path, temp_dir)
+
+        return 'Project successfully exported to %s' % output_path
+
+    def _copy_previous_results(self, export_dir):
+        """
+        Copy previous S2E analysis results for this project.
+
+        Args:
+            export_dir: Path to the temporary directory that will be exported.
+        """
+        for s2e_out_path in glob.glob(self.project_path('s2e-out-*')):
+            s2e_out_dir = os.path.basename(s2e_out_path)
+            logger.info('Copying %s', s2e_out_dir)
+            shutil.copytree(s2e_out_path, os.path.join(export_dir, s2e_out_dir))
+
+    def _create_archive(self, archive_path, export_dir):
+        """
+        Create the final archive of all the exported project files.
+
+        Args:
+            archive_path: Path to the ``tar.xz`` archive.
+            export_dir: Path to the directory containing the files to export.
+        """
+        try:
+            logger.info('Creating archive %s', archive_path)
+            create_archive = tar.bake(create=True, xz=True, verbose=True,
+                                      file=archive_path, directory=export_dir,
+                                      _fg=True, _out=sys.stdout,
+                                      _err=sys.stderr)
+            create_archive(self._project_name)
+        except ErrorReturnCode as e:
+            raise CommandError('Failed to archive project - %s' % e)

--- a/s2e_env/commands/import_export/__init__.py
+++ b/s2e_env/commands/import_export/__init__.py
@@ -1,0 +1,50 @@
+"""
+Copyright (c) 2017 Dependable Systems Laboratory, EPFL
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+
+import os
+
+from s2e_env import CONSTANTS
+from s2e_env.command import CommandError
+
+
+S2E_ENV_PLACEHOLDER = '<S2E_ENV_PATH>'
+
+
+def copy_and_rewrite_files(input_dir, output_dir, to_replace, replace_with):
+    """
+    Copy files from ``input_dir`` to ``output_dir`` and replace all occurances
+    of ``to_replace`` with ``replace_with``.
+    """
+    for file_ in CONSTANTS['exported_files']:
+        in_file_path = os.path.join(input_dir, file_)
+        out_file_path = os.path.join(output_dir, file_)
+
+        if not os.path.isfile(in_file_path):
+            raise CommandError('%s does not exist' % file_)
+
+        # We need to do this to correctly handle in_file_path == out_file_path
+        contents = ''
+        with open(in_file_path, 'r') as f:
+            contents = f.read()
+        with open(out_file_path, 'w') as f:
+            f.write(contents.replace(to_replace, replace_with))

--- a/s2e_env/commands/import_project.py
+++ b/s2e_env/commands/import_project.py
@@ -1,0 +1,156 @@
+"""
+Copyright (c) 2017 Dependable Systems Laboratory, EPFL
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+
+import json
+import logging
+import os
+import shutil
+import sys
+
+from sh import tar, ErrorReturnCode
+
+from s2e_env import CONSTANTS
+from s2e_env.command import EnvCommand, CommandError
+from s2e_env.commands.import_export import S2E_ENV_PLACEHOLDER, copy_and_rewrite_files
+
+
+logger = logging.getLogger('import')
+
+
+def _get_project_name(archive):
+    """
+    Get the project name from the archive.
+
+    The project name is the name of the root directory in the archive.
+    """
+    try:
+        contents = tar(exclude='*/*', list=True, file=archive)
+        return os.path.dirname(str(contents))
+    except ErrorReturnCode as e:
+        raise CommandError('Failed to list archive - %s' % e)
+
+
+class Command(EnvCommand):
+    """
+    Import a project exported from another S2E environment.
+
+    This command can be used on any archive exported via the ``s2e
+    export_project`` command.
+
+    All of the files in the archive will be exported to the new project, and
+    those listed under ``exported_files`` in ``config.yaml`` will be rewritten
+    so that the placeholder marker inserted by the ``s2e export_project``
+    command is replaced by the S2E environment path.
+    """
+
+    help = 'Import an S2E project from an archive'
+
+    def add_arguments(self, parser):
+        super(Command, self).add_arguments(parser)
+
+        parser.add_argument('archive', nargs=1,
+                            help='The path to the exported project archive')
+        parser.add_argument('-f', '--force', action='store_true',
+                            help='If a project with the same name as the '
+                                 'imported project already exists, replace it')
+
+    def handle(self, *args, **options):
+        # Check the archive
+        archive = options['archive'][0]
+        if not os.path.isfile(archive):
+            raise CommandError('%s is not a valid project archive' % archive)
+
+        # Get the name of the project that we are importing
+        project_name = _get_project_name(archive)
+        logger.info('Importing project \'%s\' from %s', project_name, archive)
+
+        # Check if a project with that name already exists
+        project_path = self.projects_path(project_name)
+        if os.path.isdir(project_path):
+            if options['force']:
+                logger.info('\'%s\' already exists - removing', project_name)
+                shutil.rmtree(self.projects_path(project_name))
+            else:
+                raise CommandError('\'%s\' already exists. Either remove this '
+                                   'project or use the force option' % project_name)
+
+        # Decompress the archive
+        self._decompress_archive(archive)
+
+        # Rewrite all of the exported files to fix their S2E environment paths
+        logger.info('Rewriting project files')
+        copy_and_rewrite_files(project_path, project_path,
+                               S2E_ENV_PLACEHOLDER, self.env_path())
+
+        with open(os.path.join(project_path, 'project.json'), 'r') as f:
+            proj_desc = json.load(f)
+
+            # Create a symlink to the guest tools directory
+            self._symlink_guest_tools(project_path, proj_desc)
+
+            # Create a symlink to guestfs (if it exists)
+            if proj_desc['has_guestfs']:
+                self._symlink_guestfs(project_path, proj_desc)
+
+        return 'Project successfully imported from %s' % archive
+
+    def _decompress_archive(self, archive_path):
+        """
+        Decompress the given archive into the S2E environment's projects
+        directory.
+        """
+        try:
+            logger.info('Decompressing archive %s', archive_path)
+            tar(extract=True, xz=True, verbose=True, file=archive_path,
+                directory=self.projects_path(), _fg=True, _out=sys.stdout,
+                _err=sys.stderr)
+        except ErrorReturnCode as e:
+            raise CommandError('Failed to decompress project archive - %s', e)
+
+    def _symlink_guest_tools(self, project_path, project_desc):
+        """
+        Create a symlink to the guest tools directory.
+        """
+        qemu_arch = project_desc['image']['qemu_build']
+        guest_tools_path = \
+            self.install_path('bin', CONSTANTS['guest_tools'][qemu_arch])
+
+        logger.info('Creating a symlink to %s', guest_tools_path)
+        os.symlink(guest_tools_path,
+                   os.path.join(project_path, 'guest-tools'))
+
+    def _symlink_guestfs(self, project_path, project_desc):
+        """
+        Create a symlink to the image's guestfs directory.
+        """
+        image_name = os.path.dirname(project_desc['image']['path'])
+        guestfs_path = self.image_path(image_name, 'guestfs')
+
+        if not os.path.exists(guestfs_path):
+            logger.warn('%s does not exist, despite the original project '
+                        'using the guestfs. The VMI plugin may not run '
+                        'optimally', guestfs_path)
+
+        logger.info('Creating a symlink to %s', guestfs_path)
+        os.symlink(guestfs_path,
+                   os.path.join(project_path, 'guestfs'))

--- a/s2e_env/dat/config.yaml
+++ b/s2e_env/dat/config.yaml
@@ -125,7 +125,7 @@ dirs:
     - projects
     - source
 
-# Mapping of architecture to guest tools directory
+# Mapping of QEMU architecture to guest tools directory
 guest_tools:
     i386: guest-tools32
     x86_64: guest-tools64

--- a/s2e_env/dat/config.yaml
+++ b/s2e_env/dat/config.yaml
@@ -130,7 +130,7 @@ guest_tools:
     i386: guest-tools32
     x86_64: guest-tools64
 
-# Functions that are supported by S2E's FunctionModels plugin
+# Functions that are supported by S2E's ``FunctionModels`` plugin
 function_models:
     - strcpy
     - strncpy
@@ -143,3 +143,12 @@ function_models:
     - fprintf
     - strcat
     - strncat
+
+# Project files exported by the ``s2e export_project`` command
+exported_files:
+    - bootstrap.sh
+    - launch-s2e.sh
+    - library.lua
+    - models.lua
+    - project.json
+    - s2e-config.lua

--- a/s2e_env/manage.py
+++ b/s2e_env/manage.py
@@ -130,8 +130,8 @@ class CommandManager(object):
         """
         commands = find_commands()
         if subcommand not in commands:
-            sys.stderr.write('Unknown command - %r' % subcommand)
-            sys.stderr.write('Type \'%s help\' for usage\n' % self._prog_name)
+            sys.stderr.write('Unknown command - %r. Type \'%s help\' for '
+                             'usage\n' % (subcommand, self._prog_name))
             sys.exit(1)
 
         return load_command_class(subcommand)

--- a/s2e_env/templates/bootstrap.windows.sh
+++ b/s2e_env/templates/bootstrap.windows.sh
@@ -34,7 +34,7 @@ function execute_target_with_seed {
 
 function target_init {
     local PREFIX
-    {% if image.os.arch=='x86_64' %}
+    {% if image_arch=='x86_64' %}
     # The driver must be installed by a 64-bit process, otherwise
     # its files are copied into syswow64.
     # We use /c/Windows/sysnative to access 64-bit apps from 32-bit msys.

--- a/s2e_env/templates/bootstrap.windows_dll.sh
+++ b/s2e_env/templates/bootstrap.windows_dll.sh
@@ -12,7 +12,7 @@ function execute_target {
 
 function target_init {
     local PREFIX
-    {% if image.os.arch=='x86_64' %}
+    {% if image_arch=='x86_64' %}
     # The driver must be installed by a 64-bit process, otherwise
     # its files are copied into syswow64.
     # We use /c/Windows/sysnative to access 64-bit apps from 32-bit msys.

--- a/s2e_env/templates/launch-s2e.sh
+++ b/s2e_env/templates/launch-s2e.sh
@@ -6,8 +6,9 @@
 # arguments can be passed to this script at run time
 #
 
-INSTALL_DIR="{{ install_dir }}"
-BUILD_DIR="{{ build_dir }}"
+ENV_DIR="{{ env_dir }}"
+INSTALL_DIR="$ENV_DIR/install"
+BUILD_DIR="$ENV_DIR/build/s2e"
 BUILD=debug
 
 # Comment this out to enable QEMU GUI
@@ -18,10 +19,10 @@ if [ "x$1" = "xdebug" ]; then
   shift
 fi
 
-DRIVE="-drive file={{ image_path }},format=s2e,cache=writeback"
+DRIVE="-drive file=$ENV_DIR/{{ rel_image_path }},format=s2e,cache=writeback"
 
 export S2E_CONFIG=s2e-config.lua
-export S2E_SHARED_DIR={{ install_dir }}/share/libs2e
+export S2E_SHARED_DIR=$INSTALL_DIR/share/libs2e
 export S2E_MAX_PROCESSES=1
 export S2E_UNBUFFERED_STREAM=1
 
@@ -32,8 +33,8 @@ if [ ! -d "$BUILD_DIR/qemu-$BUILD" ]; then
     exit 1
 fi
 
-QEMU="$BUILD_DIR/qemu-$BUILD/{{ arch }}-softmmu/qemu-system-{{ arch }}"
-LIBS2E="$BUILD_DIR/libs2e-$BUILD/{{ arch }}-s2e-softmmu/libs2e.so"
+QEMU="$BUILD_DIR/qemu-$BUILD/{{ qemu_arch }}-softmmu/qemu-system-{{ qemu_arch }}"
+LIBS2E="$BUILD_DIR/libs2e-$BUILD/{{ qemu_arch }}-s2e-softmmu/libs2e.so"
 
 cat >> gdb.ini <<EOF
 handle SIGUSR2 noprint
@@ -50,18 +51,18 @@ EOF
 GDB="gdb  --init-command=gdb.ini --args"
 
 $GDB $QEMU $DRIVE \
-    -k en-us $GRAPHICS -monitor null -m {{ memory }} -enable-kvm \
+    -k en-us $GRAPHICS -monitor null -m {{ qemu_memory }} -enable-kvm \
     -serial file:serial.txt {{ qemu_extra_flags }} \
-    -loadvm {{ snapshot }} $*
+    -loadvm {{ qemu_snapshot }} $*
 
 else
 
-QEMU="$INSTALL_DIR/bin/qemu-system-{{ arch }}"
-LIBS2E="$INSTALL_DIR/share/libs2e/libs2e-{{ arch }}-s2e.so"
+QEMU="$INSTALL_DIR/bin/qemu-system-{{ qemu_arch }}"
+LIBS2E="$INSTALL_DIR/share/libs2e/libs2e-{{ qemu_arch }}-s2e.so"
 
 LD_PRELOAD=$LIBS2E $QEMU $DRIVE \
-    -k en-us $GRAPHICS -monitor null -m {{ memory }} -enable-kvm \
+    -k en-us $GRAPHICS -monitor null -m {{ qemu_memory }} -enable-kvm \
     -serial file:serial.txt {{ qemu_extra_flags }} \
-    -loadvm {{ snapshot }} $*
+    -loadvm {{ qemu_snapshot }} $*
 
 fi

--- a/s2e_env/templates/s2e-config.lua
+++ b/s2e_env/templates/s2e-config.lua
@@ -64,7 +64,7 @@ add_plugin("Vmi")
 pluginsConfig.Vmi = {
     baseDirs = {
         "{{ project_dir }}",
-        {% if guestfs_dir %}
+        {% if has_guestfs %}
         "{{ guestfs_dir }}"
         {% endif %}
     },


### PR DESCRIPTION
Just something I did for "fun" over the weekend.

Allows the user to export projects to share with others (e.g. to upload to the s2e-dev google group, share with other S2E users, etc.). When exporting a project, all references to the S2E environment path are replaced with a placeholder that gets rewritten with the new S2E environment path when imported.

I wanted to add a `--contact-vitaly` option to the `s2e export_project` command for when people need help, but maybe that wait for a future PR 🙂