### PR TITLE
Different apt dep for Ubuntu 16.10

### DIFF
--- a/s2e_env/dat/config.yaml
+++ b/s2e_env/dat/config.yaml
@@ -80,7 +80,7 @@ dependencies:
         # s2e-env dependencies
         - lcov
     ubuntu_16:
-        - libprocps4-dev
+        - libprocps-dev
     ubuntu_14:
         - libprocps3-dev
     ida:


### PR DESCRIPTION
Tried running `s2e init` on my Ubuntu 16.10. The apt requirement didn't exist as stated. Would think that allowing it to be generic would work across the different 16s.