### PR TITLE
s2e init error fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ might be the analysis of the ``file`` program from
 
 # Prerequisites
 
-We assume that you are working on Ubuntu 14.04 (or newer) 64-bit OS.
+We assume that you are working on an Ubuntu 14.04 or 16.04 64-bit OS.
 [Repo](https://code.google.com/p/git-repo/) only works with Python 2.7, so you
 should use Python 2.7 too.
 

--- a/s2e_env/commands/init.py
+++ b/s2e_env/commands/init.py
@@ -83,9 +83,13 @@ def _install_dependencies():
                        CONSTANTS['dependencies']['ida']
 
     try:
-        apt_get = sudo.bake('apt-get', _fg=True)
+        # Enable 32-bit libraries
+        dpkg_add_arch = sudo.bake('dpkg', add_architecture=True, _fg=True)
+        dpkg_add_arch('i386')
 
         # Perform apt-get install
+        apt_get = sudo.bake('apt-get', _fg=True)
+        apt_get.update()
         apt_get.install(install_packages)
     except ErrorReturnCode as e:
         raise CommandError(e)
@@ -169,7 +173,7 @@ def _get_repo(env_path):
 
 def _download_repo(repo_path):
     """
-    Download repo.
+    Download Google's repo.
     """
     logger.info('Fetching repo')
 

--- a/s2e_env/commands/init.py
+++ b/s2e_env/commands/init.py
@@ -109,7 +109,7 @@ def _get_ubuntu_version():
 
     major_version = int(version.split('.')[0])
 
-    if major_version < 14:
+    if major_version not in CONSTANTS['required_versions']['ubuntu_major_ver']:
         logger.warning('You are running an unsupported version of Ubuntu. '
                        'Skipping S2E dependencies  - please install them '
                        'manually')

--- a/s2e_env/dat/config.yaml
+++ b/s2e_env/dat/config.yaml
@@ -105,6 +105,10 @@ repos:
         build: guest-images
 
 required_versions:
+    # Ubuntu OS major version
+    ubuntu_major_ver:
+        - 14
+        - 16
     # images.json must have this version
     guest_images: 2
 


### PR DESCRIPTION
Enable 32-bit libraries and makes clearer what versions of Ubuntu we support.

Fixes issues #33, #34 and #36.