### PR TITLE
Added ExecutionTracer.dat parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ A typical workflow is therefore:
 6. Change into the project directory and run the S2E analysis with the
    `launch-s2e.sh` script.
 7. After your analysis has finished, a number of subcommands exist to analyze
-   and summarize your results, e.g. the ``coverage`` subcommand, etc.
+   and summarize your results, e.g. the ``coverage`` and ``execution_trace``
+   subcommands.
 
 Other useful commands:
 

--- a/s2e_env/commands/execution_trace.py
+++ b/s2e_env/commands/execution_trace.py
@@ -1,0 +1,108 @@
+"""
+Copyright (c) 2017 Dependable Systems Laboratory, EPFL
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+
+import json
+import logging
+
+from s2e_env.command import ProjectCommand, CommandError
+from s2e_env.execution_trace import parse as parse_execution_tree, trace_entries
+from s2e_env.execution_trace.trace_entries import TraceEntryType
+
+
+logger = logging.getLogger('execution_trace')
+
+
+def _make_json_trace(execution_trace):
+    """
+    Make an execution trace (consisting of ``TraceEntry`` objects)
+    JSON-serializable.
+    """
+    return [_make_json_entry(header, item) for header, item in execution_trace]
+
+
+def _make_json_entry(header, item):
+    """
+    Combine a trace entry header and item into a single JSON-serializable
+    entry. Return this entry as a ``dict``.
+
+    Some things to note:
+        * The header's ``size`` field is removed - it is not required in the
+          JSON
+        * Enums are replaced by their numerical value (so that they can be
+          written to JSON)
+    """
+    from enum import Enum
+
+    # If the entry is a fork, then we have to make the child traces
+    # JSON-serializable as well
+    if header.type == TraceEntryType.TRACE_FORK:
+        children = {state_id: _make_json_trace(trace) for state_id, trace in item.children.items()}
+        item = trace_entries.TraceFork(item.pc, children)
+
+    header_dict = header.as_dict()
+
+    del header_dict['size']
+
+    entry = header_dict.copy()
+    entry.update(item.as_dict())
+
+    for key, value in entry.items():
+        if isinstance(value, Enum):
+            entry[key] = value.value
+
+    return entry
+
+
+class Command(ProjectCommand):
+    """
+    Parses an execution trace into JSON.
+    """
+
+    help = 'Parse an S2E execution trace into JSON.'
+
+    def add_arguments(self, parser):
+        super(Command, self).add_arguments(parser)
+
+        parser.add_argument('-p', '--path-id', action='append', type=int,
+                            dest='path_ids',
+                            help='Path IDs to include in the trace. This '
+                                 'option can be used multiple times to trace '
+                                 'multiple path IDs')
+
+    def handle(self, *args, **options):
+        # Parse the ExecutionTracer.dat file(s) and generate an execution tree
+        # for the given path IDs
+        results_dir = self.project_path('s2e-last')
+        execution_tree = parse_execution_tree(results_dir, path_ids=options['path_ids'])
+        if not execution_tree:
+            raise CommandError('The execution trace is empty')
+
+        # Convert the tree into a JSON representation
+        execution_tree_json = _make_json_trace(execution_tree)
+
+        # Write the execution tree to a JSON file
+        json_trace_file = self.project_path('s2e-last', 'execution_trace.json')
+        with open(json_trace_file, 'w') as f:
+            json.dump(execution_tree_json, f)
+
+        return 'Execution trace saved to %s' % json_trace_file

--- a/s2e_env/execution_trace/__init__.py
+++ b/s2e_env/execution_trace/__init__.py
@@ -1,0 +1,361 @@
+"""
+Copyright (c) 2017 Dependable Systems Laboratory, EPFL
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+
+import glob
+import logging
+import operator
+import os
+
+from . import trace_entries
+from .trace_entries import TraceEntryType, TraceEntryError, TraceItemHeader
+
+
+logger = logging.getLogger('execution_trace')
+
+
+# Maps trace entry types to a class
+_TRACE_ENTRY_MAP = {
+    TraceEntryType.TRACE_MOD_LOAD: trace_entries.TraceModuleLoad,
+    TraceEntryType.TRACE_MOD_UNLOAD: trace_entries.TraceModuleUnload,
+    TraceEntryType.TRACE_PROC_UNLOAD: trace_entries.TraceProcessUnload,
+    TraceEntryType.TRACE_CALL: trace_entries.TraceCall,
+    TraceEntryType.TRACE_RET: trace_entries.TraceReturn,
+    TraceEntryType.TRACE_TB_START: trace_entries.TraceTranslationBlock,
+    TraceEntryType.TRACE_TB_END: trace_entries.TraceTranslationBlock,
+    TraceEntryType.TRACE_MODULE_DESC: None,
+    TraceEntryType.TRACE_FORK: trace_entries.TraceFork,
+    TraceEntryType.TRACE_CACHESIM: trace_entries.TraceCache,
+    TraceEntryType.TRACE_TESTCASE: trace_entries.TraceTestCase,
+    TraceEntryType.TRACE_BRANCHCOV: trace_entries.TraceBranchCoverage,
+    TraceEntryType.TRACE_MEMORY: trace_entries.TraceMemory,
+    TraceEntryType.TRACE_PAGEFAULT: trace_entries.TracePageFault,
+    TraceEntryType.TRACE_TLBMISS: trace_entries.TraceTLBMiss,
+    TraceEntryType.TRACE_ICOUNT: trace_entries.TraceInstructionCount,
+    TraceEntryType.TRACE_MEM_CHECKER: trace_entries.TraceMemChecker,
+    TraceEntryType.TRACE_EXCEPTION: trace_entries.TraceException,
+    TraceEntryType.TRACE_STATE_SWITCH: trace_entries.TraceStateSwitch,
+    TraceEntryType.TRACE_TB_START_X64: trace_entries.TraceTranslationBlock64,
+    TraceEntryType.TRACE_TB_END_X64: trace_entries.TraceTranslationBlock64,
+    TraceEntryType.TRACE_BLOCK: trace_entries.TraceBlock,
+}
+
+
+class ExecutionTraceParser(object):
+    """
+    Parser for S2E execution trace files.
+
+    The parsing algorithm is described below. Note that "state" and "path" are
+    used interchangably (the term "state" is used in the S2E code base, however
+    a state is essentially an execution path through a program).
+
+    If S2E is run in multiprocess mode, each process will create and write to
+    its own ``ExecutionTracer.dat`` file. So first we parse each
+    ``ExecutionTracer.dat`` file individually.
+
+    While parsing we maintain a global (i.e. across all trace files) map of
+    state IDs to parent state ID and fork points (the ``_path_info``
+    attribute). This map is then used to reconstruct the final execution tree
+    once all traces have been parsed.
+
+    Take the following execution tree, where ``Sx`` refers to a state ID with
+    ID ``x``:
+
+    .. code-block::
+
+        S0
+        |
+        S0
+        |
+        S0
+        | \
+        S0 S1
+        |  |
+        S0 S1
+        .  | \
+        .  S1 S2
+        .  |  |
+        .  .  .
+
+    After parsing the ``ExecutionTracer.dat`` file(s) the ``_execution_traces``
+    map will look as follows:
+
+    .. code-block::
+
+        _execution_traces = {
+            0: [S0_0, S0_1, S0_2, S0_3, S0_4, ...],
+            1: [S1_0, S1_1, S1_2, ...],
+            2: [S2_0, ...],
+        }
+
+    We iterate over ``_execution_traces`` from the highest state ID (i.e. the
+    state that was forked last) to the lowest (state 0, the initial state).
+
+    For each execution trace, its parent and fork point is looked up in
+    ``_path_info``. In this example, S2's parent is S1 and fork point is 1
+    (because the fork occurred at index 1 of the S1 execution trace list).
+    Because the fork point is at 1, we know that the ``TraceItemEntry`` at
+    index 1 is a ``TraceFork`` object. We then take the S2 execution trace list
+    and insert it into the ``TraceFork``'s ``children`` attribute.
+
+    Repeating the process for S1, we get parent state S0 and fork point 2
+    (because the fork occurred at index 2 of the S0 execution trace list). Once
+    again we can insert the S1 list into the ``children`` attribute at this
+    fork point.
+
+    Finally, we terminate because S0 has no parent. The entire execution tree
+    is now stored in the S0 execution trace list.
+
+    Now assume that the user is only interested in S1. During the initial file
+    parsing phase, we can assume that any state > 1 is forked after S1 is
+    forked and hence is of no interest. Therefore we do not need to store the
+    data associated with these states.
+
+    During the construction of the final tree, we can further discard
+    information that is no longer required. For example, after S0 forks S1, we
+    are no longer interested in the remainder of S0 (i.e. elements ``[S0_3,
+    S0_4, ...]`` in ``_execution_traces[0]``). Likewise if the user is only
+    interested in S2, then all of the trace entries that follow S2's fork point
+    (i.e. ``[S1_2, ...]``) and S1's fork point (i.e. ``[S0_3, S0_4, ...]``) can
+    be discarded.
+
+    Attributes:
+        _trace_files: A list of ``ExecutionTracer.dat`` file paths.
+        _execution_traces: A dictionary of state IDs to the execution trace (a
+                           list of ``(TraceItemHeader, TraceEntry)`` tuples).
+        _path_info: A map of state IDs to a tuple containing:
+                        1. The parent state's ID
+                        2. A "fork point". This is an index into state ID's
+                           trace in the ``_execution_traces`` dictionary. This
+                           index points to to a ``TraceFork`` object and hence
+                           where a fork occurred.
+    """
+
+    def __init__(self, trace_files):
+        self._trace_files = trace_files
+        self._execution_traces = {}
+        self._path_info = {}
+
+    def parse(self, path_ids=None):
+        """
+        Parse the list of trace files and generate a single execution tree
+        representing the complete trace.
+
+        The execution tree is a list of ``(TraceItemHeader, TraceEntry)``
+        tuples. If the ``TraceEntry`` is a ``TraceFork``, the list splits into
+        ``n`` sublists, where ``n`` is the number of child states forked. These
+        sublists can be accessed through the ``TraceFork``'s ``children``
+        attribute.
+
+        Args:
+            path_ids: Optional list of path (state) IDs to include in the
+                      execution tree. If no path IDs are given, the complete
+                      execution tree is parsed.
+        """
+        # Parse individual trace files
+        for trace_file_path in self._trace_files:
+            with open(trace_file_path, 'r') as trace_file:
+                logger.debug('Parsing %s', trace_file_path)
+                self._parse_trace_file(trace_file, path_ids)
+
+        # Sort the execution trace for each state
+        for execution_trace in self._execution_traces.values():
+            execution_trace.sort(key=lambda x: x[0].timestamp)
+
+        # If a list of path IDs is given, we will return these states plus
+        # their parents.
+        #
+        # If no path IDs are given, we will return all states.
+        if path_ids:
+            states_to_return = set(path_ids)
+            for state_id in path_ids:
+                parent_states = self._get_parent_states(state_id)
+                states_to_return.update(parent_states)
+
+            # Exclude the initial state, state 0, because that will always be
+            # the root of the execution tree
+            states_to_return.discard(0)
+        else:
+            states_to_return = self._path_info.keys()
+
+        # Reconstruct the execution tree for the given state IDs
+        for state_id in sorted(states_to_return, reverse=True):
+            parent_state_id, fork_point = self._path_info[state_id]
+            parent_execution_trace = self._execution_traces[parent_state_id]
+            _, trace_fork = parent_execution_trace[fork_point]
+
+            trace_fork.children[state_id] = self._execution_traces.get(state_id, [])
+
+            # If the parent's execution trace is not one we are interested in,
+            # stop following it once it forks to a path that we are interested
+            # in
+            if path_ids and parent_state_id not in path_ids:
+                del parent_execution_trace[fork_point + 1:]
+
+        return self._execution_traces[0]
+
+    def _parse_trace_file(self, trace_file, path_ids=None):
+        """
+        Parse a single ``trace_file``.
+
+        This method will iterate over all of the entries in the given trace
+        file. An S2E execution trace file (typically stored in
+        ``ExecutionTracer.dat``) is a binary file that contains data recorded
+        by S2E's ``ExecutionTracer`` plugins. The trace file is essentially an
+        array of ``(header, item)`` tuples. The header (of type
+        ``TraceItemHeader``) describes the size and type of the corresponding
+        item. Base on this information we can then parse the item and
+        instantiate the correct ``TraceEntry`` class.
+
+        The following information is recorded and stored in the class's
+        attributes:
+            * The execution trace data (a list of ``(TraceItemHeader,
+              TraceEntry)`` tuples) for the states found in the ``trace_file``.
+            * For each state ID found in the ``trace_file``, record its parent
+              state ID. This is so that we can reconstruct the execution tree
+              once all of the trace files have been individually parsed.
+            * If a state forks, record the "fork point". This is just an index
+              into the execution trace list and is also used for reconstructing
+              the final execution tree.
+
+        If ``path_ids`` is specified, only states with an ID less than the
+        maximum path ID will be saved.
+        """
+        # The maximum state ID to return an execution trace for
+        max_path_id = max(path_ids) if path_ids else None
+
+        # Map of state IDs to the number of entries for that particular
+        # state/path. Used for determining fork points.
+        path_lengths = {}
+
+        while True:
+            raw_header = trace_file.read(TraceItemHeader.static_size())
+
+            # An empty header signifies EOF
+            if not raw_header:
+                break
+
+            header = TraceItemHeader.deserialize(raw_header)
+
+            # Determine the item's type from the header
+            item_type = header.type
+            item_class = _TRACE_ENTRY_MAP.get(item_type)
+            if not item_class:
+                # If an unknown item type is found, just skip it
+                logger.warn('Found unknown trace item `%s`. Skipping %d '
+                            'bytes...', item_type.value, header.size)
+                trace_file.read(header.size)
+                continue
+
+            # Read the raw data and deserialize it
+            raw_item = trace_file.read(header.size)
+            item = item_class.deserialize(raw_item, header.size)
+
+            # Skip any states that have an ID greater than that which we have
+            # been asked to parse
+            current_state_id = header.state_id
+            if path_ids and current_state_id > max_path_id:
+                continue
+
+            # If the item is a state fork, we must update the ``_path_info``
+            # dictionary with the parent and fork point information
+            if item_type == TraceEntryType.TRACE_FORK:
+                new_children = {}
+
+                for child_state_id in item.children:
+                    # For each child state, save:
+                    #   * The state ID of the parent
+                    #   * The index into the current state's execution trace
+                    #     indicating where the fork occured
+                    #   * Create a entry for the new state in the main trace
+                    #     dictionary
+                    if child_state_id != current_state_id:
+                        fork_point = path_lengths.get(current_state_id, 0)
+                        self._path_info[child_state_id] = current_state_id, fork_point
+
+                        # When parsed directly from the trace file, the
+                        # ``children`` attribute in a ``TraceFork`` object is a
+                        # list of state IDs. To correctly represent the
+                        # execution trace, we transform this list into a
+                        # dictionary mapping state IDs to a new execution trace
+                        # (i.e. a list of ``(TraceItemHeader, TraceEntry)``
+                        # tuples). This list is initially empty.
+                        new_children[child_state_id] = []
+
+                # Since a ``TraceEntry`` is immutable, we have to create a new
+                # one if we want to use the ``new_children`` dictionary
+                item = trace_entries.TraceFork(item.pc, new_children)
+
+            # Append the ``(TraceItemHeader, TraceEntry)`` tuple to the
+            # execution trace for this state
+            if current_state_id not in self._execution_traces:
+                self._execution_traces[current_state_id] = []
+            self._execution_traces[current_state_id].append((header, item))
+
+            # Update the path length information for future fork points
+            if current_state_id not in path_lengths:
+                path_lengths[current_state_id] = 0
+            path_lengths[current_state_id] += 1
+
+    def _get_parent_states(self, state_id):
+        """
+        Get the list of parent state IDs for the given ``state_id``.
+        """
+        current_state_id = state_id
+        parent_states = []
+
+        while current_state_id:
+            current_state_id, _ = self._path_info.get(current_state_id)
+            parent_states.append(current_state_id)
+
+        return parent_states
+
+
+def parse(results_dir, path_ids=None):
+    """
+    Parse the trace file(s) generated by S2E's execution tracer plugins.
+
+    The ``ExecutionTracer`` plugin will write one or more
+    ``ExecutionTracer.dat`` files depending on the number of S2E processes
+    created when running S2E. These will be individually parsed by an
+    ``ExecutionTraceParser`` and then the results combined to form a single
+    execution tree.
+
+    Args:
+        results_dir: Path to an ``s2e-out-*`` directory in an analysis project.
+
+    Returns:
+        An execution tree of all states executed by S2E.
+    """
+    # Get the ExecutionTracer.dat file(s). Include both multi-node and single
+    # node results
+    execution_trace_files = glob.glob(os.path.join(results_dir, '*', 'ExecutionTracer.dat')) + \
+                            glob.glob(os.path.join(results_dir, 'ExecutionTracer.dat'))
+
+    if not execution_trace_files:
+        logger.warning('No \'ExecutionTrace.dat\' file found in s2e-last. Did '
+                       'you enable any trace plugins in s2e-config.lua?')
+        return []
+
+    # Parse the execution trace file(s) to construct a single execution tree.
+    execution_trace_parser = ExecutionTraceParser(execution_trace_files)
+    return execution_trace_parser.parse(path_ids)

--- a/s2e_env/execution_trace/trace_entries.py
+++ b/s2e_env/execution_trace/trace_entries.py
@@ -1,0 +1,1099 @@
+"""
+Copyright (c) 2017 Dependable Systems Laboratory, EPFL
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+
+import struct
+
+from enum import Enum
+
+#
+# The following code is a Python adaption of the C++ code in
+# libs2eplugins/src/s2e/Plugins/ExecutionTracers/TraceEntries.h
+#
+
+class TraceEntryType(Enum):
+    """
+    The different types of trace entries that can be logged.
+    """
+
+    TRACE_MOD_LOAD = 0
+    TRACE_MOD_UNLOAD = 1
+    TRACE_PROC_UNLOAD = 2
+    TRACE_CALL = 3
+    TRACE_RET = 4
+    TRACE_TB_START = 5
+    TRACE_TB_END = 6
+    TRACE_MODULE_DESC = 7
+    TRACE_FORK = 8
+    TRACE_CACHESIM = 9
+    TRACE_TESTCASE = 10
+    TRACE_BRANCHCOV = 11
+    TRACE_MEMORY = 12
+    TRACE_PAGEFAULT = 13
+    TRACE_TLBMISS = 14
+    TRACE_ICOUNT = 15
+    TRACE_MEM_CHECKER = 16
+    TRACE_EXCEPTION = 17
+    TRACE_STATE_SWITCH = 18
+    TRACE_TB_START_X64 = 19
+    TRACE_TB_END_X64 = 20
+    TRACE_BLOCK = 21
+    TRACE_MAX = 22
+
+
+class TraceEntryError(Exception):
+    """
+    An error occurred with a trace entry.
+    """
+    pass
+
+
+class TraceEntry(object):
+    """
+    Abstract trace entry class.
+
+    Defines how a particular trace entry is serialized when logged and
+    deserialized when read from a log.
+
+    Depending on the trace entry type (as defined by the ``TraceEntryType``
+    enum), the format of a trace entry may be static or dynamic. If a trace
+    entry format is static, then the corresponding trace entry will have a
+    consistent size and format whenever it is serialized/deserialized. If a
+    trace entry is not static, then the entry probably contains a variable
+    number of elements that can only be determined at run-time.
+
+    The static trace entry format is defined in the ``FORMAT`` class attribute
+    and its size can be determined using the ``static_size`` class method.
+
+    The dynamic trace entry format is defined in the ``_struct`` attribute
+    and its size can be determined using the ``len`` function.
+
+    Note that ``TraceEntry``'s default ``deserialize`` method will only work if
+    the trace entry's format can be determined statically. Otherwise the user
+    must implement their own deserialize routine (e.g. as is done in the
+    ``TraceFork`` class). When calling a custom ``deserialize`` method the
+    run-time size of the item **must** be provided.
+    """
+
+    FORMAT = None
+
+    def __init__(self, fmt=''):
+        self._struct = struct.Struct(fmt)
+
+    def __len__(self):
+        """
+        The length of the object when serialized.
+        """
+        return self._struct.size
+
+    def as_dict(self):
+        """
+        Get a dictionary representation of the trace entry.
+
+        This method should be overwritten.
+        """
+        return {}
+
+    def __str__(self):
+        return '%s(%s)' % (self.__class__.__name__,
+                           ', '.join('%s=%s' % (key, value) for key, value in self.as_dict().items()))
+
+    @classmethod
+    def static_size(cls):
+        try:
+            return struct.calcsize(cls.FORMAT)
+        except struct.error:
+            raise TraceEntryError('Cannot statically determine the size of %s' % cls.__name__)
+
+    @classmethod
+    def deserialize(cls, data, size=None):
+        try:
+            unpacked_data = struct.unpack(cls.FORMAT, data)
+            return cls(*unpacked_data)
+        except struct.error:
+            raise TraceEntryError('Cannot deserialize %s data' % cls.__name__)
+
+    def serialize(self):
+        """
+        Serializes the object using the given ``_struct`` property. The user
+        must specify the order that elements are serialized.
+
+        E.g.
+
+        ```
+        def serialize(self):
+            return self._struct.pack(self._elems['foo'], self._elems['bar'])
+        ```
+        """
+        raise NotImplementedError('Subclasses of TraceEntry must provide a '
+                                  'serialize() method')
+
+
+class TraceItemHeader(TraceEntry):
+    FORMAT = '<QIBIQ'
+
+    def __init__(self, timestamp, size, type_, state_id, pid):
+        super(TraceItemHeader, self).__init__(TraceItemHeader.FORMAT)
+        self._timestamp = timestamp
+        self._size = size
+        self._type = TraceEntryType(type_)
+        self._state_id = state_id
+        self._pid = pid
+
+    def serialize(self):
+        return self._struct.pack(self._timestamp,
+                                 self._size,
+                                 self._type,
+                                 self._state_id,
+                                 self._pid)
+
+    def as_dict(self):
+        return {
+            'timestamp': self.timestamp,
+            'size': self.size,
+            'type': self.type,
+            'stateId': self.state_id,
+            'pid': self.pid,
+        }
+
+    @property
+    def timestamp(self):
+        return self._timestamp
+
+    @property
+    def size(self):
+        return self._size
+
+    @property
+    def type(self):
+        return self._type
+
+    @property
+    def state_id(self):
+        return self._state_id
+
+    @property
+    def pid(self):
+        return self._pid
+
+
+class TraceModuleLoad(TraceEntry):
+    FORMAT = '<32s256sQQQQQ'
+
+    def __init__(self, name, path, load_base, native_base, size, address_space,
+                 pid):
+        super(TraceModuleLoad, self).__init__(TraceModuleLoad.FORMAT)
+        self._name = name
+        self._path = path
+        self._load_base = load_base
+        self._native_base = native_base
+        self._size = size
+        self._address_space = address_space
+        self._pid = pid
+
+    def serialize(self):
+        return self._struct.pack(self._name,
+                                 self._path,
+                                 self._load_base,
+                                 self._native_base,
+                                 self._size,
+                                 self._address_space,
+                                 self._pid)
+
+    def as_dict(self):
+        return {
+            'name': self.name,
+            'path': self.path,
+            'loadBase': self.load_base,
+            'nativeBase': self.native_base,
+            'size': self.size,
+            'addressSpace': self.address_space,
+            'pid': self.pid,
+        }
+
+    @property
+    def name(self):
+        return self._name.rstrip('\0')
+
+    @property
+    def path(self):
+        return self._path.rstrip('\0')
+
+    @property
+    def load_base(self):
+        return self._load_base
+
+    @property
+    def native_base(self):
+        return self._native_base
+
+    @property
+    def size(self):
+        return self._size
+
+    @property
+    def address_space(self):
+        return self._address_space
+
+    @property
+    def pid(self):
+        return self._pid
+
+
+class TraceModuleUnload(TraceEntry):
+    FORMAT = '<Q'
+
+    def __init__(self, load_base):
+        super(TraceModuleUnload, self).__init__(TraceModuleUnload.FORMAT)
+        self._load_base = load_base
+
+    def serialize(self):
+        return self._struct.pack(self._load_base)
+
+    def as_dict(self):
+        return {
+            'loadBase': self.load_base,
+        }
+
+    @property
+    def load_base(self):
+        return self._load_base
+
+
+class TraceProcessUnload(TraceEntry):
+    FORMAT = '<'
+
+    def serialize(self):
+        return ''
+
+    def as_dict(self):
+        return {}
+
+
+class TraceCall(TraceEntry):
+    FORMAT = '<QQ'
+
+    def __init__(self, source, target):
+        super(TraceCall, self).__init__(TraceCall.FORMAT)
+        self._source = source
+        self._target = target
+
+    def serialize(self):
+        return self._struct.pack(self._source, self._target)
+
+    def as_dict(self):
+        return {
+            'source': self.source,
+            'target': self.target,
+        }
+
+    @property
+    def source(self):
+        return self._source
+
+    @property
+    def target(self):
+        return self._target
+
+
+class TraceReturn(TraceEntry):
+    FORMAT = '<QQ'
+
+    def __init__(self, source, target):
+        super(TraceReturn, self).__init__(TraceReturn.FORMAT)
+        self._source = source
+        self._target = target
+
+    def serialize(self):
+        return self._struct.pack(self._source, self._target)
+
+    def as_dict(self):
+        return {
+            'source': self.source,
+            'target': self.target,
+        }
+
+    @property
+    def source(self):
+        return self._source
+
+    @property
+    def target(self):
+        return self._target
+
+
+class TraceFork(TraceEntry):
+    FORMAT = '<QI%dI'
+
+    def __init__(self, pc, children):
+        super(TraceFork, self).__init__(TraceFork.FORMAT % len(children))
+        self._pc = pc
+        self._children = children
+
+    @classmethod
+    def deserialize(cls, data, size=None):
+        if not size:
+            raise TraceEntryError('A size must be provided when deserializing '
+                                  'a ``TraceFork`` item')
+        num_children = (size - struct.calcsize('<QI')) / struct.calcsize('<I')
+        unpacked_data = struct.unpack(TraceFork.FORMAT % num_children, data)
+
+        return TraceFork(unpacked_data[0], unpacked_data[2:])
+
+    def serialize(self):
+        return self._struct.pack(self._pc,
+                                 len(self._children),
+                                 *self._children)
+
+    def as_dict(self):
+        return {
+            'pc': self.pc,
+            'children': self.children,
+        }
+
+    @property
+    def pc(self):
+        return self._pc
+
+    @property
+    def children(self):
+        return self._children
+
+
+class TraceBranchCoverage(TraceEntry):
+    FORMAT = '<QQ'
+
+    def __init__(self, pc, dest_pc):
+        super(TraceBranchCoverage, self).__init__(TraceBranchCoverage.FORMAT)
+        self._pc = pc
+        self._dest_pc = dest_pc
+
+    def serialize(self):
+        return self._struct.pack(self._pc, self._dest_pc)
+
+    def as_dict(self):
+        return {
+            'pc': self.pc,
+            'destPc': self.dest_pc,
+        }
+
+    @property
+    def pc(self):
+        return self._pc
+
+    @property
+    def dest_pc(self):
+        return self._dest_pc
+
+
+class TraceCacheSimType(Enum):
+    CACHE_PARAMS = 0
+    CACHE_NAME = 1
+    CACHE_ENTRY = 2
+
+
+class TraceCacheSimParams(TraceEntry):
+    FORMAT = '<BIIIII'
+
+    def __init__(self, type_, cache_id, size, line_size, associativity,
+                 upper_cache_id):
+        super(TraceCacheSimParams, self).__init__(TraceCacheSimParams.FORMAT)
+        self._type = type_
+        self._cache_id = cache_id
+        self._size = size
+        self._line_size = line_size
+        self._associativity = associativity
+        self._upper_cache_id = upper_cache_id
+
+    def serialize(self):
+        return self._struct.pack(self._type,
+                                 self._cache_id,
+                                 self._size,
+                                 self._line_size,
+                                 self._associativity,
+                                 self._upper_cache_id)
+
+    def as_dict(self):
+        return {
+            'type': self.type,
+            'cacheId': self.cache_id,
+            'size': self.size,
+            'lineSize': self.line_size,
+            'associativity': self.associativity,
+            'upperCacheId': self.upper_cache_id,
+        }
+
+    @property
+    def type(self):
+        return TraceCacheSimType(self._type)
+
+    @property
+    def cache_id(self):
+        return self._cache_id
+
+    @property
+    def size(self):
+        return self._size
+
+    @property
+    def line_size(self):
+        return self._line_size
+
+    @property
+    def associativity(self):
+        return self._associativity
+
+    @property
+    def upper_cache_id(self):
+        return self._upper_cache_id
+
+
+class TraceCacheSimName(TraceEntry):
+    FORMAT = '<BII%ds'
+
+    def __init__(self, type_, id_, name):
+        super(TraceCacheSimName, self).__init__(TraceCacheSimName.FORMAT % len(name))
+        self._type = type_
+        self._id = id_
+        self._name = name
+
+    @classmethod
+    def deserialize(cls, data, size=None):
+        if not size:
+            raise TraceEntryError('A size must be provided when deserializing '
+                                  'a ``TraceCacheSimName`` item')
+        length = (size - struct.calcsize('<BII')) / struct.calcsize('<c')
+        unpacked_data = struct.unpack(TraceCacheSimName.FORMAT % length, data)
+
+        return TraceCacheSimName(*unpacked_data)
+
+    def serialize(self):
+        return self._struct.pack(self._type,
+                                 self._id,
+                                 len(self._name),
+                                 self._name)
+
+    def as_dict(self):
+        return {
+            'type': self.type,
+            'id': self.id,
+            'name': self.name,
+        }
+
+    @property
+    def type(self):
+        return TraceCacheSimType(self._type)
+
+    @property
+    def id(self):
+        return self._id
+
+    @property
+    def name(self):
+        return self._name
+
+
+class TraceCacheSimEntry(TraceEntry):
+    FORMAT = '<BBQQBBBB'
+
+    def __init__(self, type_, cache_id, pc, address, size, is_write, is_code,
+                 miss_count):
+        super(TraceCacheSimEntry, self).__init__(TraceCacheSimEntry.FORMAT)
+        self._type = type_
+        self._cache_id = cache_id
+        self._pc = pc
+        self._address = address
+        self._size = size
+        self._is_write = is_write
+        self._is_code = is_code
+        self._miss_count = miss_count
+
+    def serialize(self):
+        return self._struct.pack(self._type,
+                                 self._cache_id,
+                                 self._pc,
+                                 self._address,
+                                 self._size,
+                                 self._is_write,
+                                 self._is_code,
+                                 self._miss_count)
+
+    def as_dict(self):
+        return {
+            'type': self.type,
+            'cacheId': self.cache_id,
+            'pc': self.pc,
+            'address': self.address,
+            'size': self.size,
+            'isWrite': self.is_write,
+            'isCode': self.is_code,
+            'missCount': self.miss_count,
+        }
+
+    @property
+    def type(self):
+        return TraceCacheSimType(self._type)
+
+    @property
+    def cache_id(self):
+        return self._cache_id
+
+    @property
+    def pc(self):
+        return self._pc
+
+    @property
+    def address(self):
+        return self._address
+
+    @property
+    def size(self):
+        return self._size
+
+    @property
+    def is_write(self):
+        return self._is_write
+
+    @property
+    def is_code(self):
+        return self._is_code
+
+    @property
+    def miss_count(self):
+        return self._miss_count
+
+
+class TraceCache(TraceEntry):
+    FORMAT = '<B{params}s%ds{entry}s'.format(params=TraceCacheSimParams.static_size(),
+                                             entry=TraceCacheSimEntry.static_size())
+
+    def __init__(self, type_, params, name, entry):
+        super(TraceCache, self).__init__(TraceCache.FORMAT % len(name))
+        self._type = type_
+        self._params = params
+        self._name = name
+        self._entry = entry
+
+    @classmethod
+    def deserialize(cls, data, size=None):
+        if not size:
+            raise TraceEntryError('A size must be provided when deserializing '
+                                  'a ``TraceCache`` item')
+        name_length = (size - struct.calcsize('<B') - TraceCacheSimParams.static_size() -
+                       TraceCacheSimEntry.static_size()) / struct.calcsize('<c')
+        unpacked_data = struct.unpack(TraceCache.FORMAT % name_length, data)
+
+        params = TraceCacheSimParams.deserialize(unpacked_data[1])
+        name = TraceCacheSimName.deserialize(unpacked_data[2], name_length)
+        entry = TraceCacheSimEntry.deserialize(unpacked_data[3])
+
+        return TraceCache(unpacked_data[0], params, name, entry)
+
+    def serialize(self):
+        return self._struct.pack(self._type,
+                                 self._params.serialize(),
+                                 self._name.serialize(),
+                                 self._entry.serialize())
+
+    def as_dict(self):
+        return {
+            'type': self.type,
+            'params': self.params,
+            'name': self.name,
+            'entry': self.entry,
+        }
+
+    @property
+    def type(self):
+        return self._type
+
+    @property
+    def params(self):
+        return self._params
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def entry(self):
+        return self._entry
+
+
+class TraceMemChecker(TraceEntry):
+    class Flags(Enum):
+        GRANT = 1
+        REVOKE = 2
+        READ = 4
+        WRITE = 8
+        EXECUTE = 16
+        RESOURCE = 32
+
+    FORMAT = '<QIII%ds'
+
+    def __init__(self, start, size, flags, name):
+        super(TraceMemChecker, self).__init__(TraceMemChecker.FORMAT)
+        self._start = start
+        self._size = size
+        self._flags = flags
+        self._name = name
+
+    @classmethod
+    def deserialize(cls, data, size=None):
+        if not size:
+            raise TraceEntryError('A size must be provided when deserializing '
+                                  'a ``TraceMemChecker`` item')
+        name_length = (size - struct.calcsize('<QIII')) / struct.calcsize('<c')
+        unpacked_data = struct.unpack(TraceMemChecker.FORMAT % name_length, data)
+
+        return TraceMemChecker(*unpacked_data)
+
+    def serialize(self):
+        return self._struct.pack(self._start,
+                                 self._size,
+                                 self._flags,
+                                 len(self._name),
+                                 self._name)
+
+    def as_dict(self):
+        return {
+            'start': self.start,
+            'size': self.size,
+            'flags': self.flags,
+            'name': self.name,
+        }
+
+    @property
+    def start(self):
+        return self._start
+
+    @property
+    def size(self):
+        return self._size
+
+    @property
+    def flags(self):
+        return self._flags
+
+    @property
+    def name(self):
+        return self._name
+
+
+class TraceTestCase(TraceEntry):
+    FORMAT = '<II%ds%ds'
+
+    def __init__(self, name, data):
+        super(TraceTestCase, self).__init__(TraceTestCase.FORMAT % (len(name), len(data)))
+        self._name = name
+        self._data = data
+
+    @classmethod
+    def deserialize(cls, data, size=None):
+        if not size:
+            raise TraceEntryError('A size must be provided when deserializing '
+                                  'a ``TraceTestCase`` item')
+        name_data_size_struct_fmt = '<II'
+        name_data_size_struct_size = struct.calcsize(name_data_size_struct_fmt)
+        name_size, data_size = struct.unpack(name_data_size_struct_fmt,
+                                             data[:name_data_size_struct_size])
+        unpacked_data = struct.unpack(TraceTestCase.FORMAT % (name_size, data_size), data)
+
+        return TraceTestCase(*unpacked_data[2:])
+
+    def serialize(self):
+        return self._struct.pack(len(self._name),
+                                 len(self._data),
+                                 self._name,
+                                 self._data)
+
+    def as_dict(self):
+        return {
+            'name': self.name,
+            'data': self.data,
+        }
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def data(self):
+        return self._data
+
+
+class TraceMemory(TraceEntry):
+    FORMAT = '<QQQBBQQ'
+
+    def __init__(self, pc, address, value, size, flags, host_address,
+                 concrete_buffer):
+        super(TraceMemory, self).__init__(TraceMemory.FORMAT)
+        self._pc = pc
+        self._address = address
+        self._value = value
+        self._size = size
+        self._flags = flags
+        self._host_address = host_address
+        self._concrete_buffer = concrete_buffer
+
+    def serialize(self):
+        return self._struct.pack(self._pc,
+                                 self._address,
+                                 self._value,
+                                 self._size,
+                                 self._flags,
+                                 self._host_address,
+                                 self._concrete_buffer)
+
+    def as_dict(self):
+        return {
+            'pc': self.pc,
+            'address': self.address,
+            'value': self.value,
+            'size': self.size,
+            'flags': self.flags,
+            'hostAddress': self.host_address,
+            'concreteBuffer': self.concrete_buffer,
+        }
+
+    @property
+    def pc(self):
+        return self._pc
+
+    @property
+    def address(self):
+        return self._address
+
+    @property
+    def value(self):
+        return self._value
+
+    @property
+    def size(self):
+        return self._size
+
+    @property
+    def flags(self):
+        return self._flags
+
+    @property
+    def host_address(self):
+        return self._host_address
+
+    @property
+    def concrete_buffer(self):
+        return self._concrete_buffer
+
+
+class TracePageFault(TraceEntry):
+    FORMAT = '<QQB'
+
+    def __init__(self, pc, address, is_write):
+        super(TracePageFault, self).__init__(TracePageFault.FORMAT)
+        self._pc = pc
+        self._address = address
+        self._is_write = is_write
+
+    def serialize(self):
+        return self._struct.pack(self._pc, self._address, self._is_write)
+
+    def as_dict(self):
+        return {
+            'pc': self.pc,
+            'address': self.address,
+            'isWrite': self.is_write,
+        }
+
+    @property
+    def pc(self):
+        return self._pc
+
+    @property
+    def address(self):
+        return self._address
+
+    @property
+    def is_write(self):
+        return self._is_write
+
+
+class TraceTLBMiss(TraceEntry):
+    FORMAT = '<QQB'
+
+    def __init__(self, pc, address, is_write):
+        super(TraceTLBMiss, self).__init__(TraceTLBMiss.FORMAT)
+        self._pc = pc
+        self._address = address
+        self._is_write = is_write
+
+    def serialize(self):
+        return self._struct.pack(self._pc, self._address, self._is_write)
+
+    def as_dict(self):
+        return {
+            'pc': self.pc,
+            'address': self.address,
+            'isWrite': self.is_write,
+        }
+
+    @property
+    def pc(self):
+        return self._pc
+
+    @property
+    def address(self):
+        return self._address
+
+    @property
+    def is_write(self):
+        return self._is_write
+
+
+class TraceInstructionCount(TraceEntry):
+    FORMAT = '<Q'
+
+    def __init__(self, count):
+        super(TraceInstructionCount, self).__init__(TraceInstructionCount.FORMAT)
+        self._count = count
+
+    def serialize(self):
+        return self._struct.pack(self._count)
+
+    def as_dict(self):
+        return {
+            'count': self.count,
+        }
+
+    @property
+    def count(self):
+        return self._count
+
+
+class TraceTranslationBlock(TraceEntry):
+    class TranslationBlockType(Enum):
+        TB_DEFAULT = 0
+        TB_JMP = 1
+        TB_JMP_IND = 2
+        TB_COND_JMP = 3
+        TB_COND_JMP_IND = 4
+        TB_CALL = 5
+        TB_CALL_IND = 6
+        TB_REP = 7
+        TB_RET = 8
+
+    class X86Registers(Enum):
+        EAX = 0
+        ECX = 1
+        EDX = 2
+        EBX = 3
+        ESP = 4
+        EBP = 5
+        ESI = 6
+        EDI = 7
+
+    class TranslationBlockFlags(Enum):
+        RUNNING_CONCRETE = 1 << 0
+        RUNNING_EXCEPTION_EMULATION_CODE = 1 << 1
+
+    FORMAT = '<QQIBBB8Q'
+
+    def __init__(self, pc, target_pc, size, tb_type, flags, symb_mask,
+                 registers):
+        super(TraceTranslationBlock, self).__init__(TraceTranslationBlock.FORMAT)
+        self._pc = pc
+        self._target_pc = target_pc
+        self._size = size
+        self._tb_type = tb_type
+        self._flags = flags
+        self._symb_mask = symb_mask
+        self._registers = registers
+
+    def serialize(self):
+        return self._struct.pack(self._pc,
+                                 self._target_pc,
+                                 self._size,
+                                 self._tb_type,
+                                 self._flags,
+                                 self._symb_mask,
+                                 *self._registers)
+
+    def as_dict(self):
+        return {
+            'pc': self.pc,
+            'targetPc': self.target_pc,
+            'size': self.size,
+            'tbType': self.tb_type,
+            'flags': self.flags,
+            'symbMask': self.symb_mask,
+            'registers': self.registers,
+        }
+
+    @property
+    def pc(self):
+        return self._pc
+
+    @property
+    def target_pc(self):
+        return self._target_pc
+
+    @property
+    def size(self):
+        return self._size
+
+    @property
+    def tb_type(self):
+        return TraceTranslationBlock.TranslationBlockType(self._tb_type)
+
+    @property
+    def flags(self):
+        return TraceTranslationBlock.TranslationBlockFlags(self._flags)
+
+    @property
+    def symb_mask(self):
+        return self._symb_mask
+
+    @property
+    def registers(self):
+        return self._registers
+
+
+class TraceBlock(TraceEntry):
+    class TranslationBlockType(Enum):
+        TB_DEFAULT = 0
+        TB_JMP = 1
+        TB_JMP_IND = 2
+        TB_COND_JMP = 3
+        TB_COND_JMP_IND = 4
+        TB_CALL = 5
+        TB_CALL_IND = 6
+        TB_REP = 7
+        TB_RET = 8
+
+    FORMAT = '<QQB'
+
+    def __init__(self, start_pc, end_pc, tb_type):
+        super(TraceBlock, self).__init__(TraceBlock.FORMAT)
+        self._start_pc = start_pc
+        self._end_pc = end_pc
+        self._tb_type = tb_type
+
+    def serialize(self):
+        return self._struct.pack(self._start_pc, self._end_pc, self._tb_type)
+
+    def as_dict(self):
+        return {
+            'startPc': self.start_pc,
+            'endPc': self.end_pc,
+            'tbType': self.tb_type,
+        }
+
+    @property
+    def start_pc(self):
+        return self._start_pc
+
+    @property
+    def end_pc(self):
+        return self._end_pc
+
+    @property
+    def tb_type(self):
+        return TraceBlock.TranslationBlockType(self._tb_type)
+
+
+class TraceTranslationBlock64(TraceEntry):
+    FORMAT = '<SB8Q'
+
+    def __init__(self, base, symb_mask, extended_registers):
+        super(TraceTranslationBlock64, self).__init__(TraceTranslationBlock64.FORMAT)
+        self._base = base
+        self._symb_mask = symb_mask
+        self._extended_registers = extended_registers
+
+    def serialize(self):
+        return self._struct.pack(self._base.serialize(),
+                                 self._symb_mask,
+                                 *self._extended_registers)
+
+    def as_dict(self):
+        return {
+            'base': self.base,
+            'symbMask': self.symb_mask,
+            'extendedRegisters': self.extended_registers,
+        }
+
+    @property
+    def base(self):
+        return self._base
+
+    @property
+    def symb_mask(self):
+        return self._symb_mask
+
+    @property
+    def extended_registers(self):
+        return self._extended_registers
+
+
+class TraceException(TraceEntry):
+    FORMAT = '<QI'
+
+    def __init__(self, pc, vector):
+        super(TraceException, self).__init__(TraceException.FORMAT)
+        self._pc = pc
+        self._vector = vector
+
+    def serialize(self):
+        return self._struct.pack(self._pc, self._vector)
+
+    def as_dict(self):
+        return {
+            'pc': self.pc,
+            'vector': self.vector,
+        }
+
+    @property
+    def pc(self):
+        return self._pc
+
+    @property
+    def vector(self):
+        return self._vector
+
+
+class TraceStateSwitch(TraceEntry):
+    FORMAT = '<I'
+
+    def __init__(self, new_state_id):
+        super(TraceStateSwitch, self).__init__(TraceStateSwitch.FORMAT)
+        self._new_state_id = new_state_id
+
+    def serialize(self):
+        return self._struct.pack(self._new_state_id)
+
+    def as_dict(self):
+        return {
+            'newStateId': self.new_state_id,
+        }
+
+    @property
+    def new_state_id(self):
+        return self._new_state_id

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         'pygments',
 
         # s2e-env requirements
+        'enum34',
         'jinja2',
         'pefile',
         'psutil',


### PR DESCRIPTION
New command to parse an Execution trace into human-readable JSON. Works for both single and multi process traces.

Allows the user to specify specific paths to include in the trace - all other paths are filtered out.