### PR TITLE
elf: fixed function models check

### DIFF
--- a/s2e_env/analysis/elf.py
+++ b/s2e_env/analysis/elf.py
@@ -86,13 +86,15 @@ class ELFAnalysis(object):
                     symbol['st_info']['type'] == 'STT_FUNC' and
                     symbol.name in CONSTANTS['function_models'])
 
-        # Find the symbol table
+        # Find the symbol table(s)
+        modelled_functions = set()
         for section in self._elf.iter_sections():
             if isinstance(section, SymbolTableSection):
                 # Look for a function that is supported by the FunctionModels
                 # plugin
-                modelled_functions = [symbol.name for symbol in
-                                      section.iter_symbols()
-                                      if is_modelled_func(symbol)]
+                for symbol in section.iter_symbols():
+                    if is_modelled_func(symbol):
+                        modelled_functions.add(symbol.name)
 
-        return modelled_functions
+        # Must return a list so we can serialize it to JSON
+        return list(modelled_functions)

--- a/s2e_env/dat/config.yaml
+++ b/s2e_env/dat/config.yaml
@@ -143,6 +143,8 @@ function_models:
     - fprintf
     - strcat
     - strncat
+    - crc16
+    - crc32
 
 # Project files exported by the ``s2e export_project`` command
 exported_files:


### PR DESCRIPTION
An ELF file can have multiple symbol tables. If this is the case, then the `modelled_functions` list could be blatted out by multiple symbol tables.

I've changed the way we construct this list to prevent this from happening.