### PR TITLE
models.lua: made static function models config clearer

### DIFF
--- a/s2e_env/templates/models.lua
+++ b/s2e_env/templates/models.lua
@@ -6,6 +6,7 @@ Suppose that the binary you want to analyze contains at address 0x1234 a functio
 that computes a standard CRC32 checksum. To enable the model for the CRC32 function,
 add the following lines:
 
+g_function_models["{{ target }}"] = {}
 g_function_models["{{ target }}"][0x1234] = {
     xor_result=true, --Must be true for standard CRC32
     type="crc32"


### PR DESCRIPTION
I've had a few people make this mistake (yes, including me!) - replace
```lua
g_function_models["{{ target }}"] = {}
```
with
```lua
g_function_models["{{ target }}"][0x1234] = {
     xor_result=true, --Must be true for standard CRC32
     type="crc32"
 }
```
And then the models don't work because the table at `g_function_models["{{ target }}"]` doesn't exist.

Hopefully this makes it clearer that the empty table should not be replaced!