### PR TITLE
s2e-config.linux.lua: incorrect LinuxMonitor option

### DIFF
--- a/s2e_env/templates/s2e-config.linux.lua
+++ b/s2e_env/templates/s2e-config.linux.lua
@@ -10,7 +10,7 @@
 add_plugin("LinuxMonitor")
 pluginsConfig.LinuxMonitor = {
     -- Kill the execution state when it encounters a segfault
-    terminateOnSegFault = true,
+    terminateOnSegfault = true,
 
     -- Kill the execution state when it encounters a trap
     terminateOnTrap = true,


### PR DESCRIPTION
`terminateOnSegfault` not `terminateOnSegFault`.