### PR TITLE
templates: minor fixes

### DIFF
--- a/s2e_env/templates/instructions.txt
+++ b/s2e_env/templates/instructions.txt
@@ -84,8 +84,8 @@ Running S2E
 
 The S2E project is now ready to run. You have two ways to start the analysis:
 
-    * Use the "s2e run" command
     * cd {{ project_dir }} && ./launch-s2e.sh
+    * Use the "s2e run" command
 
 The results of the analysis can be found in the s2e-last directory.
 You may customize s2e-config.lua, bootstrap.sh, launch-s2e.sh, and others

--- a/s2e_env/templates/s2e-config.lua
+++ b/s2e_env/templates/s2e-config.lua
@@ -43,7 +43,7 @@ add_plugin("BaseInstructions")
 -- Use it in conjunction with s2eget and s2eput guest tools in order to
 -- transfer files between the guest and the host.
 
-table.insert(plugins, "HostFiles")
+add_plugin("HostFiles")
 pluginsConfig.HostFiles = {
     baseDirs = {
         "{{ project_dir }}",


### PR DESCRIPTION
Preference running launch-s2e.sh over the "s2e run" command (because "s2e run" is not very useful for non-CGC binaries).