### PR TITLE
Make s2e-env more "virtualenv"-ish

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,17 @@ To get help on a particular command:
 s2e <subcommand> --help
 ```
 
-All commands take an optional `--env /path/to/env` argument to specify the
-path to the S2E environment you want to execute the command in. If not provided
-this path defaults to the current working directory. For the workflow described
-below it is easiest to execute all commands from within your S2E environment
-directory.
+Most commands use the `S2EDIR` environment variable so that commands can be run
+from any directory. `S2EDIR` can be set by sourcing `install/bin/s2e_activate`
+in your environment directory. Sourcing this file also makes `s2e_deactivate`
+available, which unsets S2E environment variables.
+
+Alternatively, most commands take an optional `--env /path/to/env` argument.
+This argument can be used to specify the path to the S2E environment you want
+to execute the command in.
+
+Note that **one of** the `S2EDIR` environment variable or `--env` option
+**must** be used.
 
 ## Workflow
 
@@ -87,20 +93,21 @@ A typical workflow is therefore:
 1. Run `s2e init $DIR` to create a new S2E environment in `$DIR`. This will
    create the environment, install dependencies (unless `--skip-dependencies`
    is used) and fetch all of the S2E engine code.
-2. Look around the source code, make some modifications, etc. Then when you are
+2. Activate the environment via `. $DIR/install/bin/s2e_activate`.
+3. Look around the source code, make some modifications, etc. Then when you are
    ready to build run `s2e build`.
-3. You'll need some images to analyze your software in! See what images are
+4. You'll need some images to analyze your software in! See what images are
    available with `s2e image_build`.
-4. Run `s2e image_build $TEMPLATE` to build one of the images listed in the
+5. Run `s2e image_build $TEMPLATE` to build one of the images listed in the
    previous step. This will create the image in the `images` directory.
-5. Use `s2e new_project` to create a new analysis project. This will create all
+6. Use `s2e new_project` to create a new analysis project. This will create all
    the launch scripts, configuration files and bootstrap scripts necessary to
    perform the analysis on a given target. Currently Linux ELF executables,
    Decree CGC binaries, Windows PE executables and Windows DLLs can be
    targeted with the `new_project` command.
-6. Change into the project directory and run the S2E analysis with the
+7. Change into the project directory and run the S2E analysis with the
    `launch-s2e.sh` script.
-7. After your analysis has finished, a number of subcommands exist to analyze
+8. After your analysis has finished, a number of subcommands exist to analyze
    and summarize your results, e.g. the ``coverage`` and ``execution_trace``
    subcommands.
 

--- a/s2e_env/command.py
+++ b/s2e_env/command.py
@@ -249,9 +249,16 @@ class EnvCommand(BaseCommand):
     def handle_common_args(self, **options):
         """
         Adds the environment directory as a class member.
+
+        The environment directory is specified as either an environment
+        variable or a command-line option.
         """
-        self._env_dir = options['env']
-        options.pop('env', ())
+        self._env_dir = os.getenv('S2EDIR') or options.pop('env', None)
+
+        if not self._env_dir:
+            raise CommandError('The S2E environment directory could not be '
+                               'determined. Source install/bin/s2e_activate '
+                               'in your environment or use the --env option')
 
         try:
             with open(self.env_path('s2e.yaml'), 'r') as f:
@@ -266,9 +273,9 @@ class EnvCommand(BaseCommand):
     def add_arguments(self, parser):
         super(EnvCommand, self).add_arguments(parser)
 
-        parser.add_argument('-e', '--env', default=os.getcwd(), required=False,
-                            help='The S2E development environment. Defaults '
-                                 'to the current working directory')
+        parser.add_argument('-e', '--env', required=False,
+                            help='The S2E environment. Only used if the '
+                                 'S2EDIR environment variable is not defined')
 
     @property
     def config(self):

--- a/s2e_env/commands/init.py
+++ b/s2e_env/commands/init.py
@@ -234,7 +234,9 @@ class Command(BaseCommand):
     help = 'Initializes a new S2E environment.'
 
     def add_arguments(self, parser):
-        parser.add_argument('dir', help='The environment directory')
+        parser.add_argument('dir', nargs='?', default=os.getcwd(),
+                            help='The environment directory. Defaults to the '
+                                 'current working directory')
         parser.add_argument('-s', '--skip-dependencies', action='store_true',
                             help='Skip the dependency install via apt')
         parser.add_argument('-b', '--use-existing-install', required=False,
@@ -250,12 +252,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         env_path = os.path.realpath(options['dir'])
 
-        # First check if we are already in the environment directory
-        if os.path.realpath(env_path) == os.path.realpath(os.getcwd()):
-            raise CommandError('You cannot create an S2E environment in the '
-                               'current working directory. Please `cd ..`')
-
-        # Then check if something already exists at the environment directory
+        # Check if something already exists at the environment directory
         if os.path.isdir(env_path) and not os.listdir(env_path) == []:
             if options['force']:
                 logger.info('%s already exists - removing', env_path)
@@ -305,7 +302,8 @@ class Command(BaseCommand):
                         'environment. Then run ``s2e build`` to build '
                         'S2E'.format(env_path))
         except:
-            # Cleanup on failure
-            if os.path.isdir(env_path):
+            # Cleanup on failure. Note that this only occurs if the chosen
+            # directory is *not* the current working directory
+            if os.path.isdir(env_path) and os.getcwd() != env_path:
                 shutil.rmtree(env_path)
             raise

--- a/s2e_env/commands/init.py
+++ b/s2e_env/commands/init.py
@@ -209,6 +209,21 @@ def _create_config(env_path):
     render_template(context, s2e_yaml, os.path.join(env_path, s2e_yaml))
 
 
+def _create_activate_script(env_path):
+    """
+    Create the environment activation script.
+    """
+    # TODO detect shell to determine template
+    template = 's2e_activate.sh'
+
+    context = {
+        'S2EDIR': env_path,
+    }
+
+    render_template(context, template,
+                    os.path.join(env_path, 'install', 'bin', 's2e_activate'))
+
+
 class Command(BaseCommand):
     """
     Initializes a new S2E environment.
@@ -268,6 +283,9 @@ class Command(BaseCommand):
             # Create the YAML config for the environment
             _create_config(env_path)
 
+            # Create the shell script to activate the environment
+            _create_activate_script(env_path)
+
             prefix = options['use_existing_install']
             if prefix is not None:
                 _install_binary_dist(env_path, prefix)
@@ -281,9 +299,11 @@ class Command(BaseCommand):
                 _get_s2e_sources(env_path)
                 _get_img_sources(env_path)
 
-                return ('Environment created in %s. You may wish to modify '
-                        'your environment\'s s2e.yaml config file. Run ``s2e '
-                        'build`` to build S2E' % env_path)
+                return ('Environment created in {0}. You may wish to modify '
+                        'your environment\'s s2e.yaml config file. Source '
+                        '``{0}/install/bin/s2e_activate`` to activate your '
+                        'environment. Then run ``s2e build`` to build '
+                        'S2E'.format(env_path))
         except:
             # Cleanup on failure
             if os.path.isdir(env_path):

--- a/s2e_env/templates/s2e_activate.sh
+++ b/s2e_env/templates/s2e_activate.sh
@@ -1,0 +1,33 @@
+# This file must be used with "source install/bin/s2e_activate" *from bash*.
+# You cannot run it directly
+
+s2e_deactivate() {
+    if ! [ -z "${_S2E_OLD_VIRTUAL_PS1+_}" ] ; then
+        PS1="$_S2E_OLD_VIRTUAL_PS1"
+        export PS1
+        unset _S2E_OLD_VIRTUAL_PS1
+    fi
+
+    unset S2EDIR
+
+    if [ ! "${1-}" = "nondestructive" ] ; then
+        # Self destruct!
+        unset -f s2e_deactivate
+    fi
+}
+
+# unset irrelvant variables
+s2e_deactivate nondestructive
+
+S2EDIR="{{ S2EDIR }}"
+export S2EDIR
+
+if [ -z "${S2E_ENV_DISABLE_PROMPT-}" ] ; then
+    _S2E_OLD_VIRTUAL_PS1="$PS1"
+    if [ "x" != x ] ; then
+        PS1="$PS1"
+    else
+        PS1="[S2E:`basename \"$S2EDIR\"`] $PS1"
+    fi
+    export PS1
+fi


### PR DESCRIPTION
Adds an environment activation script (currently only BASH is supported), similar to a Python virtualenv. This allows the user to run `s2e` commands from any location (previously the user had to be in the environment's root directory) and have the command run in the currently-activated environment.
  