### PR TITLE
command: returned default env directory to cwd

### DIFF
--- a/s2e_env/command.py
+++ b/s2e_env/command.py
@@ -273,9 +273,10 @@ class EnvCommand(BaseCommand):
     def add_arguments(self, parser):
         super(EnvCommand, self).add_arguments(parser)
 
-        parser.add_argument('-e', '--env', required=False,
+        parser.add_argument('-e', '--env', required=False, default=os.getcwd(),
                             help='The S2E environment. Only used if the '
-                                 'S2EDIR environment variable is not defined')
+                                 'S2EDIR environment variable is not defined. '
+                                 'Defaults to the current working directory')
 
     @property
     def config(self):


### PR DESCRIPTION
I accidentally removed this. If you are using an existing S2E environment (i.e. one that doesn't have the s2e_activate.sh script), then you'll probably get funny behaviour. Sorry! 😞