### PR TITLE
project config: convert Windows module names to lower-case

### DIFF
--- a/s2e_env/commands/new_project.py
+++ b/s2e_env/commands/new_project.py
@@ -204,6 +204,10 @@ class Command(EnvCommand):
             options['target'] = target_path
             options['target_files'] = [target_path]
             options['target_arch'] = arch
+
+            # The module list is a list of tuples where the first element is
+            # the module name and the second element is True if the module is
+            # a kernel module
             options['modules'] = [(os.path.basename(target_path), False)]
 
             options['processes'] = []


### PR DESCRIPTION
This is inline with the WindowsMonitor plugin.

Also moved the Windows configuration to a common base-class (lots of duplicate checks for 'pe' in `os_desc`).