### PR TITLE
Empty project

### DIFF
--- a/s2e_env/templates/bootstrap.sh
+++ b/s2e_env/templates/bootstrap.sh
@@ -148,6 +148,10 @@ if ! mount | grep "/tmp type tmpfs"; then
     sudo mount -t tmpfs -osize=10m tmpfs /tmp
 fi
 
+# Need to disable swap, otherwise there will be forced concretization if the
+# system swaps out symbolic data to disk.
+sudo swapoff -a
+
 {% endif %}
 
 target_init

--- a/s2e_env/templates/bootstrap.sh
+++ b/s2e_env/templates/bootstrap.sh
@@ -161,8 +161,13 @@ target_init
 ${S2EGET} "{{ tf }}"
 {% endfor %}
 
+{% if target %}
 # Run the analysis
 execute "./{{ target }}"
+{% else %}
+##### NO TARGET HAS BEEN SPECIFIED DURING PROJECT CREATION #####
+##### Please fetch and execute the target files manually   #####
+{% endif %}
 
 # Kill states before exiting
-${S2ECMD} kill $? "'{{ target }}' state killed"
+${S2ECMD} kill $? "Target execution terminated"


### PR DESCRIPTION
This is useful when there isn't really a target to analyze, or the desired target is not supported by s2e-env. This gives the option of configuring everything manually. The command still provides a default project skeleton for the type of OS requested.