### PR TITLE
bootstrap template: VM only downloads required tools

### DIFF
--- a/s2e_env/templates/bootstrap.cgc.sh
+++ b/s2e_env/templates/bootstrap.cgc.sh
@@ -36,3 +36,8 @@ function target_init {
 function target_tools {
     echo "cgccmd"
 }
+
+S2ECMD=./s2ecmd
+S2EGET=./s2eget
+S2EPUT=./s2eput
+COMMON_TOOLS="s2ecmd s2eget s2eput"

--- a/s2e_env/templates/bootstrap.linux.sh
+++ b/s2e_env/templates/bootstrap.linux.sh
@@ -56,3 +56,8 @@ function target_init {
 function target_tools {
     echo "s2e.so"
 }
+
+S2ECMD=./s2ecmd
+S2EGET=./s2eget
+S2EPUT=./s2eput
+COMMON_TOOLS="s2ecmd s2eget s2eput"

--- a/s2e_env/templates/bootstrap.sh
+++ b/s2e_env/templates/bootstrap.sh
@@ -12,11 +12,6 @@
 
 set -x
 
-S2EGET=./s2eget
-S2EPUT=./s2eput
-S2ECMD=./s2ecmd
-COMMON_TOOLS="s2ecmd s2eget s2eput"
-
 # To save you the hassle of rebuilding the image every time you want to update
 # S2E's guest tools, the first thing that we do is get the latest versions of
 # the guest tools.

--- a/s2e_env/templates/bootstrap.windows_common.sh
+++ b/s2e_env/templates/bootstrap.windows_common.sh
@@ -53,7 +53,9 @@ function win_path {
   echo "$(cd "$dir"; echo "$(pwd -W)/$fn")" | sed 's|/|\\|g';
 }
 
-cd /c/s2e
-S2EGET=./s2eget.exe
 S2ECMD=./s2ecmd.exe
+S2EGET=./s2eget.exe
+S2EPUT=./s2eput.exe
 COMMON_TOOLS="s2ecmd.exe s2eget.exe s2eput.exe"
+
+cd /c/s2e


### PR DESCRIPTION
Super small cleanup!!

Previously Windows VMs would download the Linux common tools (e.g. s2eget, etc.), which aren't usable on a Windows system.