### PR TITLE
Remove TestCaseGenerator from Linux template

### DIFF
--- a/s2e_env/templates/s2e-config.linux.lua
+++ b/s2e_env/templates/s2e-config.linux.lua
@@ -15,15 +15,3 @@ pluginsConfig.LinuxMonitor = {
     -- Kill the execution state when it encounters a trap
     terminateOnTrap = true,
 }
-
--------------------------------------------------------------------------------
--- This generates test cases when a state crashes or terminates.
--- If symbolic inputs consist of symbolic files, the test case generator writes
--- concrete files in the S2E output folder. These files can be used to
--- demonstrate the crash in a program, added to a test suite, etc.
-
-add_plugin("TestCaseGenerator")
-pluginsConfig.TestCaseGenerator = {
-    generateOnStateKill = true,
-    generateOnSegfault = true
-}


### PR DESCRIPTION
Since use_test_case_generator is true in Linux, TestCaseGenerator will be included in s2e-config.lua for Linux. However, since there is another TestCaseGenerator option in s2e-config.linux.lua, it results in duplication.