### PR TITLE
readme: updated to include process-dependency-links option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ disassemblers include:
 ```
 git clone https://github.com/S2E/s2e-env.git
 cd s2e-env
-pip install .
+pip install . --process-dependency-links
 ```
 
 If you wish to install `s2e-env` to a Python


### PR DESCRIPTION
We need to update the docs to include this `process-dependency-links` option.

I was just trying it out, and noticed that:

```
DEPRECATION: Dependency Links processing has been deprecated and will be removed in a future release.
```

We can achieve the same thing with the following requirements.txt file and removing `install_requires` from setup.py:

```
# S2E engine requirements
docutils
pygments

# s2e-env requirements
enum34
jinja2
pefile
psutil
git+https://github.com/s2e/pyelftools.git#egg=pyelftools==0.24s2e
python-magic
pyyaml
requests
sh
termcolor
pytrie
```

The downside of this is that it adds an extra step: a `pip install -r requirements.txt` before the main `pip install .`  However, I think I prefer this method, regardless of the extra step, mainly because of the deprecation notice.

Thoughts?