### PR TITLE
Use our own fixed version of pytrie

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,11 +51,14 @@ setup(
         'requests',
         'sh',
         'termcolor',
-        'pytrie',
+        'pytrie==0.3+s2e',
         'pwntools'
     ],
     packages=find_packages(),
-    dependency_links=['git+https://github.com/S2E/pyelftools.git#egg=pyelftools-0.24+s2e'],
+    dependency_links=[
+        'git+https://github.com/S2E/pyelftools.git#egg=pyelftools-0.24+s2e',
+        'git+https://github.com/S2E/pytrie.git#egg=pytrie-0.3+s2e'
+    ],
     include_package_data=True,
     package_data={
         's2e_env': [


### PR DESCRIPTION
The upstream one is not compatible with the latest sorted containers

Signed-off-by: Vitaly Chipounov <vitaly@cyberhaven.io>