### PR TITLE
templates: use env to preload libs2e.so

### DIFF
--- a/s2e_env/templates/launch-s2e.sh
+++ b/s2e_env/templates/launch-s2e.sh
@@ -48,7 +48,7 @@ set disassembly-flavor intel
 set print pretty on
 set environment S2E_CONFIG=$S2E_CONFIG
 set environment S2E_SHARED_DIR=$S2E_SHARED_DIR
-set environment LD_PRELOAD=$LIBS2E
+set exec-wrapper env 'LD_PRELOAD=$LIBS2E'
 set environment S2E_UNBUFFERED_STREAM=1
 #set environment QEMU_LOG_LEVEL=int,exec
 #set environment S2E_QMP_SERVER=127.0.0.1:3322


### PR DESCRIPTION
Using set environment was causing QEMU to wait forever on select() on the machine I'm working on (Ubuntu 16.04) but I'm not sure why since both methods should just load the library. This should be tested on other machines before merging.

Signed-off-by: Matteo Rizzo <matteo.rizzo@epfl.ch>