### PR TITLE
setup: pinned pwn tools version to one that works

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         'sh',
         'termcolor',
         'pytrie',
-        'pwntools'
+        'pwntools==3.12.0'
     ],
     packages=find_packages(),
     dependency_links=[


### PR DESCRIPTION
The latest one has conflicting requirements with other packages,
it uses an incompatible sortedcontainers.

Signed-off-by: Vitaly Chipounov <vitaly@cyberhaven.io>