### PR TITLE
Fix 's2e build -g', which didn't re-install updated binaries.

### DIFF
--- a/s2e_env/commands/build.py
+++ b/s2e_env/commands/build.py
@@ -88,7 +88,7 @@ class Command(EnvCommand):
             # Run make
             if options['debug']:
                 logger.info('Building S2E (debug) in %s', build_dir)
-                self._make('all-debug', _out=sys.stdout, _err=sys.stderr, _fg=True)
+                self._make('install-debug', _out=sys.stdout, _err=sys.stderr, _fg=True)
             else:
                 logger.info('Building S2E (release) in %s', build_dir)
                 self._make('install', _out=sys.stdout, _err=sys.stderr, _fg=True)


### PR DESCRIPTION
The 's2e build -g' command builds debug version of s2e but doesn't install it to the destination 'install' folder. I found it invokes 'make all-debug' instead of 'make install-debug'. So I guess that's the reason. Would you please confirm it?