### PR TITLE
templates: fixed gdb.ini creation + block SIGUSR1

### DIFF
--- a/s2e_env/dat/config.yaml
+++ b/s2e_env/dat/config.yaml
@@ -79,6 +79,7 @@ dependencies:
         - mingw-w64
         - gcc-multilib
         - g++-multilib
+        - libpixman-1-dev
 
         # s2e-env dependencies
         - lcov

--- a/s2e_env/templates/launch-s2e.sh
+++ b/s2e_env/templates/launch-s2e.sh
@@ -42,7 +42,8 @@ fi
 QEMU="$BUILD_DIR/qemu-$BUILD/{{ qemu_arch }}-softmmu/qemu-system-{{ qemu_arch }}"
 LIBS2E="$BUILD_DIR/libs2e-$BUILD/{{ qemu_arch }}-s2e-softmmu/libs2e.so"
 
-cat >> gdb.ini <<EOF
+cat > gdb.ini <<EOF
+handle SIGUSR1 noprint
 handle SIGUSR2 noprint
 set disassembly-flavor intel
 set print pretty on


### PR DESCRIPTION
SIGUSR1 is used by QEMU 3.0