### PR TITLE
basic_block coverage: gets stuck in infinite loop

### DIFF
--- a/s2e_env/commands/code_coverage/basic_block.py
+++ b/s2e_env/commands/code_coverage/basic_block.py
@@ -121,6 +121,8 @@ def _binary_search(tb_start_addr, bbs):
             return mid
         elif tb_start_addr <= bbs[mid].end_addr:
             hi = mid
+        elif lo == mid:
+            break
         else:
             lo = mid
 


### PR DESCRIPTION
The binary search can get stuck in an infinite loop when `mid` is assigned to `lo` and the first two checks on the tb/bb coverage do not pass. In this case, `lo` will always be the same value as `mid`, which can never be greater than `hi` and therefore the `while` loop will never exit.

I have no idea if this is the correct solution, it's late on a Friday evening...