### PR TITLE
allow early termination when timeout is set

### DIFF
--- a/s2e_env/commands/run.py
+++ b/s2e_env/commands/run.py
@@ -106,10 +106,12 @@ def _sigterm_handler(signum=None, _=None):
 
 
 def _wait_for_termination(timeout):
+    cnt = timeout * 60
     while not terminating():
         if timeout:
-            time.sleep(timeout * 60)
-            return
+            if not cnt:
+                return
+            cnt = cnt-1
         time.sleep(1)
 
 


### PR DESCRIPTION
Hi,
This patch allows early termination when execution time is less than timeout.
This patch is extremely useful and can save time when doing batch run.
Please consider pulling if you think this is useful.
Thanks.
- Tong