### PR TITLE
templates/s2e-config.lua: fixed incorrect commenting for the LuaCoreEvents example

### DIFF
--- a/s2e_env/templates/s2e-config.lua
+++ b/s2e_env/templates/s2e-config.lua
@@ -413,7 +413,7 @@ add_plugin("LuaCoreEvents")
 
 -- This configuration shows an example that kills states if they fork in
 -- a specific module.
--- [[
+--[[
 pluginsConfig.LuaCoreEvents = {
     -- This annotation is called in case of a fork. It should return true
     -- to allow the fork and false to prevent it.
@@ -435,4 +435,4 @@ function onStateForkDecide(state)
    end
    return true
 end
--- ]]
+--]]


### PR DESCRIPTION
The LuaCoreEvents example is not commented out properly, which will suppress the onStateForkDecide functions in other plugins.

Signed-off-by: Zhongjie Wang <wzj401@gmail.com>