### PR TITLE
Added BIOS project support

### DIFF
--- a/s2e_env/commands/new_project.py
+++ b/s2e_env/commands/new_project.py
@@ -30,7 +30,7 @@ from magic import Magic
 from s2e_env.command import EnvCommand, CommandError
 from s2e_env.commands.project_creation import CGCProject, LinuxProject, AbstractProject
 from s2e_env.commands.project_creation import WindowsExeProject, \
-        WindowsDLLProject, WindowsDriverProject
+        WindowsDLLProject, WindowsDriverProject, BIOSProject
 from s2e_env.commands.project_creation import Target
 from s2e_env.commands.project_creation.abstract_project import validate_arguments, SUPPORTED_TOOLS
 from s2e_env.infparser.driver import Driver
@@ -45,6 +45,7 @@ PROJECT_TYPES = {
     'windows': WindowsExeProject,
     'windows_dll': WindowsDLLProject,
     'windows_driver': WindowsDriverProject,
+    'bios': BIOSProject
 }
 
 # Paths
@@ -63,6 +64,9 @@ PE32_REGEX = re.compile(r'^PE32 executable')
 PE64_REGEX = re.compile(r'^PE32\+ executable')
 MSDOS_REGEX = re.compile(r'^MS-DOS executable')
 
+ARCH_I386 = 'i386'
+ARCH_X86_64 = 'x86_64'
+SUPPORTED_ARCHS=[ARCH_I386, ARCH_X86_64]
 
 def _determine_arch_and_proj(target_path):
     """
@@ -79,16 +83,16 @@ def _determine_arch_and_proj(target_path):
     """
     default_magic = Magic()
     magic_checks = (
-        (Magic(magic_file=CGC_MAGIC), CGC_REGEX, CGCProject, 'i386', 'decree'),
-        (default_magic, ELF32_REGEX, LinuxProject, 'i386', 'linux'),
-        (default_magic, ELF64_REGEX, LinuxProject, 'x86_64', 'linux'),
-        (default_magic, DLL32_REGEX, WindowsDLLProject, 'i386', 'windows'),
-        (default_magic, DLL64_REGEX, WindowsDLLProject, 'x86_64', 'windows'),
-        (default_magic, WIN32_DRIVER_REGEX, WindowsDriverProject, 'i386', 'windows'),
-        (default_magic, WIN64_DRIVER_REGEX, WindowsDriverProject, 'x86_64', 'windows'),
-        (default_magic, PE32_REGEX, WindowsExeProject, 'i386', 'windows'),
-        (default_magic, PE64_REGEX, WindowsExeProject, 'x86_64', 'windows'),
-        (default_magic, MSDOS_REGEX, WindowsExeProject, 'i386', 'windows'),
+        (Magic(magic_file=CGC_MAGIC), CGC_REGEX, CGCProject, ARCH_I386, 'decree'),
+        (default_magic, ELF32_REGEX, LinuxProject, ARCH_I386, 'linux'),
+        (default_magic, ELF64_REGEX, LinuxProject, ARCH_X86_64, 'linux'),
+        (default_magic, DLL32_REGEX, WindowsDLLProject, ARCH_I386, 'windows'),
+        (default_magic, DLL64_REGEX, WindowsDLLProject, ARCH_X86_64, 'windows'),
+        (default_magic, WIN32_DRIVER_REGEX, WindowsDriverProject, ARCH_I386, 'windows'),
+        (default_magic, WIN64_DRIVER_REGEX, WindowsDriverProject, ARCH_X86_64, 'windows'),
+        (default_magic, PE32_REGEX, WindowsExeProject, ARCH_I386, 'windows'),
+        (default_magic, PE64_REGEX, WindowsExeProject, ARCH_X86_64, 'windows'),
+        (default_magic, MSDOS_REGEX, WindowsExeProject, ARCH_I386, 'windows'),
     )
 
     # Need to resolve symbolic links, otherwise magic will report the file type
@@ -189,12 +193,15 @@ def _parse_sym_args(sym_args_str):
     return sym_args
 
 
-def target_from_file(path, args=None, project_class=None):
+def target_from_file(path, args=None, project_class=None, custom_arch=None):
     files = _translate_target_to_files(path)
     path_to_analyze = files[0]
     aux_files = files[1:]
 
     arch, op_sys, proj_class = _determine_arch_and_proj(path_to_analyze)
+    if not arch:
+        arch = custom_arch
+
     if not arch:
         raise Exception(f'Could not determine architecture for {path_to_analyze}')
 
@@ -208,13 +215,28 @@ def target_from_file(path, args=None, project_class=None):
 
 
 def _handle_with_file(target_path, target_args, proj_class, *args, **options):
-    target, proj_class = target_from_file(target_path, target_args, proj_class)
+    arch = options.get('arch', None)
+    if arch and arch not in SUPPORTED_ARCHS:
+        raise Exception(f'Architecture {arch} is not supported')
+
+    target, proj_class = target_from_file(target_path, target_args, proj_class, arch)
     options['target'] = target
 
     return call_command(proj_class(), *args, **options)
 
 
+def _get_project_class(**options):
+    project_types = list(PROJECT_TYPES.keys())
+    if options['type'] not in project_types:
+        raise CommandError('An empty project requires a type. Use the -t '
+                            'option and specify one from %s' % project_types)
+    return PROJECT_TYPES[options['type']]
+
+
 def _handle_empty_project(proj_class, *args, **options):
+    if not proj_class:
+        raise CommandError('Please specify a project type')
+
     if not options['no_target']:
         raise CommandError('No target binary specified. Use the -m option to '
                            'create an empty project')
@@ -226,15 +248,6 @@ def _handle_empty_project(proj_class, *args, **options):
     if not options['name']:
         raise CommandError('An empty project requires a name. Use the -n '
                            'option to specify one')
-
-    # If the project class wasn't explicitly overridden programmatically, get
-    # one of the default project classes from the command line
-    if not proj_class:
-        project_types = list(PROJECT_TYPES.keys())
-        if options['type'] not in project_types:
-            raise CommandError('An empty project requires a type. Use the -t '
-                               'option and specify one from %s' % project_types)
-        proj_class = PROJECT_TYPES[options['type']]
 
     options['target'] = Target.empty()
 
@@ -287,6 +300,10 @@ class Command(EnvCommand):
                                  'seeds themselves and place them in the '
                                  'project\'s ``seeds`` directory')
 
+        parser.add_argument('--arch', required=False, default=None,
+                            help='Architecture for binaries whose architecture cannot be autodetected. '
+                                 f'Supported architectures: {SUPPORTED_ARCHS}')
+
         parser.add_argument('--tools', type=lambda s: s.split(','),
                             default=[],
                             help='Comma-separated list of tools to enable '
@@ -312,6 +329,9 @@ class Command(EnvCommand):
         # It provides a class that is instantiated with the current
         # command-line arguments and options
         proj_class = options.pop('project_class', None)
+        if not proj_class:
+            proj_class = _get_project_class(**options)
+
         if options['target']:
             _handle_with_file(options.pop('target'), options.pop('target_args'), proj_class, *args, **options)
         else:

--- a/s2e_env/commands/project_creation/__init__.py
+++ b/s2e_env/commands/project_creation/__init__.py
@@ -28,3 +28,4 @@ from .linux_project import LinuxProject
 from .target import Target
 from .windows_project import WindowsExeProject, WindowsDLLProject, \
         WindowsDriverProject
+from .bios_project import BIOSProject

--- a/s2e_env/commands/project_creation/abstract_project.py
+++ b/s2e_env/commands/project_creation/abstract_project.py
@@ -318,7 +318,10 @@ class AbstractProject(EnvCommand):
         # when images are rebuilt. Instead, always use latest images.json
         # in guest-images repo. This avoids forcing users to create new projects
         # everytime guest image parameters change.
-        config_copy['image'] = os.path.dirname(config['image']['path'])
+        if config['image'].get('path', None):
+            config_copy['image'] = os.path.dirname(config['image']['path'])
+        else:
+            config_copy['image'] = None
 
         project_desc_path = os.path.join(project_dir, 'project.json')
         with open(project_desc_path, 'w', encoding='utf-8') as f:

--- a/s2e_env/commands/project_creation/bios_project.py
+++ b/s2e_env/commands/project_creation/bios_project.py
@@ -1,0 +1,62 @@
+"""
+Copyright (c) 2023 Vitaly Chipounov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+
+import logging
+
+from s2e_env.command import CommandError
+
+from .base_project import BaseProject
+
+
+logger = logging.getLogger('new_project')
+
+
+class BIOSProject(BaseProject):
+    supported_tools = []
+    image = {
+        "image_group": "bios",
+        "memory": "4M",
+        "name": "bios",
+        "os": None,
+        "qemu_build": "x86_64",
+        "qemu_extra_flags": "-net none -net nic,model=e1000 ",
+        "snapshot": None,
+        "version": 3
+    }
+
+    def __init__(self):
+        super().__init__(None, 's2e-config.bios.lua', BIOSProject.image)
+
+    def _is_valid_image(self, target, os_desc):
+        # Any image is ok for BIOS, they will just be ignored.
+        return True
+
+    def _finalize_config(self, config):
+        config['project_type'] = 'bios'
+
+        args = config.get('target').args.raw_args
+        if args:
+            raise CommandError('Command line arguments for BIOS binaries '
+                               'not supported')
+
+        config['bios'] = config['target'].path

--- a/s2e_env/templates/s2e-config.bios.lua
+++ b/s2e_env/templates/s2e-config.bios.lua
@@ -1,0 +1,11 @@
+add_plugin("RawMonitor")
+pluginsConfig.RawMonitor = {
+    kernelStart=0xd0000,
+    bios={
+        name="bios",
+        size=0x20000,
+        start=0xd0000,
+        nativebase=0xd0000,
+        kernelmode=true
+    }
+}

--- a/test.sh
+++ b/test.sh
@@ -30,7 +30,7 @@ SRC_DIR=${SRC_DIR:-.}
 
 python3 -m venv venv-test
 . venv-test/bin/activate
-pip install --upgrade pip
+pip install --upgrade pip wheel
 
 pip install "$SRC_DIR"
 pip install pylint pytest-cov mock


### PR DESCRIPTION
s2e new_project can now create a project for BIOSes (using -bios QEMU command line argument).
This is mostly used to configure a project to run the S2E BIOS to test the engine. No plugin/tooling is available in S2E yet.